### PR TITLE
Declare Sendable Conformances

### DIFF
--- a/Sources/ElevenLabsSwift/ElevenLabsSwift.swift
+++ b/Sources/ElevenLabsSwift/ElevenLabsSwift.swift
@@ -149,7 +149,7 @@ public class ElevenLabsSDK {
         private var currentBuffer: Data?
         private var wasInterrupted: Bool = false
         private var finished: Bool = false
-        public var onProcess: ((Bool) -> Void)?
+        public var onProcess: (@Sendable (Bool) -> Void)?
 
         public func process(outputs: inout [[Float]]) {
             var isFinished = false
@@ -642,17 +642,17 @@ public class ElevenLabsSDK {
 
     // MARK: - Conversation
 
-    public enum Role: String {
+    public enum Role: String, Sendable {
         case user
         case ai
     }
 
-    public enum Mode: String {
+    public enum Mode: String, Sendable {
         case speaking
         case listening
     }
 
-    public enum Status: String {
+    public enum Status: String, Sendable {
         case connecting
         case connected
         case disconnecting


### PR DESCRIPTION
Declares `Sendable` conformances for conversation types. This improves flexibility by allowing these types to be used in other `Sendable` types. For example:

```swift
public enum AgentEvent: Sendable {
    case error(String)
    case modeChange(ElevenLabsSDK.Mode)
    case statusChange(ElevenLabsSDK.Status)
}

func makeStream(for callbacks: inout ElevenLabsSDK.Callbacks) -> AsyncStream<AgentEvent> {
    AsyncStream { continuation in
        callbacks.onDisconnect = { continuation.finish() }
        callbacks.onError = { message, _ in
            continuation.yield(.error(message))
        }
        callbacks.onModeChange = { continuation.yield(.modeChange($0)) }
        callbacks.onStatusChange = { continuation.yield(.statusChange($0)) }
    }
}
```

This also requires `Sendable` conformance for the `ElevenLabsSDK.AudioConcatProcessor.onProcess`.