### PR TITLE
Added support for agent_tool_response event type

### DIFF
--- a/Sources/ElevenLabs/Conversation.swift
+++ b/Sources/ElevenLabs/Conversation.swift
@@ -440,7 +440,7 @@ public final class Conversation: ObservableObject, RoomDelegate {
             // Don't change agent state - let voice activity detection handle it
             appendUserTranscript(e.transcript)
 
-        case let .tentativeAgentResponse(e):
+        case .tentativeAgentResponse:
             // Don't change agent state - let voice activity detection handle it
             break
 
@@ -474,8 +474,13 @@ public final class Conversation: ObservableObject, RoomDelegate {
             // Add to pending tool calls for the app to handle
             pendingToolCalls.append(toolCall)
 
-        case let .vadScore(vadScoreEvent):
+        case .vadScore:
             // VAD scores are available in the event stream
+            break
+
+        case .agentToolResponse:
+            // Agent tool response is available in the event stream
+            // This can be used to track tool executions by the agent
             break
         }
     }

--- a/Sources/ElevenLabs/Conversation.swift
+++ b/Sources/ElevenLabs/Conversation.swift
@@ -440,7 +440,7 @@ public final class Conversation: ObservableObject, RoomDelegate {
             // Don't change agent state - let voice activity detection handle it
             appendUserTranscript(e.transcript)
 
-        case .tentativeAgentResponse:
+        case let .tentativeAgentResponse(e):
             // Don't change agent state - let voice activity detection handle it
             break
 
@@ -474,11 +474,11 @@ public final class Conversation: ObservableObject, RoomDelegate {
             // Add to pending tool calls for the app to handle
             pendingToolCalls.append(toolCall)
 
-        case .vadScore:
+        case let .vadScore(vadScoreEvent):
             // VAD scores are available in the event stream
             break
 
-        case .agentToolResponse:
+        case let .agentToolResponse(toolResponse):
             // Agent tool response is available in the event stream
             // This can be used to track tool executions by the agent
             break

--- a/Sources/ElevenLabs/Networking/Receive/DataChannelReceiver.swift
+++ b/Sources/ElevenLabs/Networking/Receive/DataChannelReceiver.swift
@@ -114,6 +114,9 @@ extension DataChannelReceiver: RoomDelegate {
 
             case let .clientToolCall(toolCallEvent):
                 handleClientToolCall(toolCallEvent)
+
+            case let .agentToolResponse(toolResponseEvent):
+                handleAgentToolResponse(toolResponseEvent)
             }
         } catch {
             logger.error("Failed to parse incoming event: \(error)")
@@ -191,5 +194,10 @@ extension DataChannelReceiver: RoomDelegate {
     private func handleClientToolCall(_ event: ClientToolCallEvent) {
         logger.info("Received client tool call: \(event.toolName) (ID: \(event.toolCallId))")
         // Tool calls are available in the event stream
+    }
+
+    private func handleAgentToolResponse(_ event: AgentToolResponseEvent) {
+        logger.info("Received agent tool response: \(event.toolName) (ID: \(event.toolCallId), Type: \(event.toolType), Error: \(event.isError))")
+        // Agent tool responses are available in the event stream
     }
 }

--- a/Sources/ElevenLabs/Protocol/EventParser.swift
+++ b/Sources/ElevenLabs/Protocol/EventParser.swift
@@ -112,6 +112,22 @@ enum EventParser {
                 }
             }
 
+        case "agent_tool_response":
+            if let event = json["agent_tool_response"] as? [String: Any],
+               let toolName = event["tool_name"] as? String,
+               let toolCallId = event["tool_call_id"] as? String,
+               let toolType = event["tool_type"] as? String,
+               let isError = event["is_error"] as? Bool
+            {
+                return .agentToolResponse(
+                    AgentToolResponseEvent(
+                        toolName: toolName,
+                        toolCallId: toolCallId,
+                        toolType: toolType,
+                        isError: isError
+                    ))
+            }
+
         default:
             throw EventParseError.unknownEventType(type)
         }

--- a/Sources/ElevenLabs/Protocol/IncomingEvents.swift
+++ b/Sources/ElevenLabs/Protocol/IncomingEvents.swift
@@ -14,6 +14,7 @@ public enum IncomingEvent: Sendable {
     case conversationMetadata(ConversationMetadataEvent)
     case ping(PingEvent)
     case clientToolCall(ClientToolCallEvent)
+    case agentToolResponse(AgentToolResponseEvent)
 }
 
 /// User's speech transcription
@@ -77,4 +78,12 @@ public struct ClientToolCallEvent: Sendable {
     public func getParameters() throws -> [String: Any] {
         try JSONSerialization.jsonObject(with: parametersData) as? [String: Any] ?? [:]
     }
+}
+
+/// Agent tool response event
+public struct AgentToolResponseEvent: Sendable {
+    public let toolName: String
+    public let toolCallId: String
+    public let toolType: String
+    public let isError: Bool
 }

--- a/Tests/ElevenLabsTests/Tests/EventParserTests.swift
+++ b/Tests/ElevenLabsTests/Tests/EventParserTests.swift
@@ -102,6 +102,32 @@ final class EventParserTests: XCTestCase {
         XCTAssertEqual(toolCall.toolName, "weather")
     }
 
+    func testParseAgentToolResponseEvent() throws {
+        let json = """
+        {
+            "type": "agent_tool_response",
+            "agent_tool_response": {
+                "tool_name": "end_call",
+                "tool_call_id": "toolu_vrtx_01Vvmrto87Dvc2RFCoCPMKzx",
+                "tool_type": "system",
+                "is_error": false
+            }
+        }
+        """.data(using: .utf8)!
+
+        let event = try EventParser.parseIncomingEvent(from: json)
+
+        guard case let .agentToolResponse(toolResponse) = event else {
+            XCTFail("Expected agentToolResponse event")
+            return
+        }
+
+        XCTAssertEqual(toolResponse.toolName, "end_call")
+        XCTAssertEqual(toolResponse.toolCallId, "toolu_vrtx_01Vvmrto87Dvc2RFCoCPMKzx")
+        XCTAssertEqual(toolResponse.toolType, "system")
+        XCTAssertEqual(toolResponse.isError, false)
+    }
+
     func testParseInvalidJSON() {
         let json = "invalid json".data(using: .utf8)!
 


### PR DESCRIPTION
**_What's changed_**

- Added AgentToolResponseEvent struct and enum case to handle agent tool execution responses
- Implemented parsing logic for the new event type in EventParser
- Added event handling in Conversation and DataChannelReceiver
- Included test coverage for the new functionality

**_Why_**

The SDK was throwing unknownEventType("agent_tool_response") errors when agents executed system tools (like end_call). This update properly handles these events.

**_Testing_**

Added unit test that validates parsing of agent_tool_response events with the exact JSON structure from production