### PR TITLE
Add support for capturing agent tool responses

### DIFF
--- a/Sources/ElevenLabs/Conversation.swift
+++ b/Sources/ElevenLabs/Conversation.swift
@@ -21,6 +21,9 @@ public final class Conversation: ObservableObject, RoomDelegate {
 
     /// Stream of client tool calls that need to be executed by the app
     @Published public private(set) var pendingToolCalls: [ClientToolCallEvent] = []
+    
+    /// Agent tool responses received during the conversation
+    @Published public private(set) var agentToolResponses: [AgentToolResponseEvent] = []
 
     // Device lists (optional to expose; keep `internal` if you don't want them public)
     @Published public private(set) var audioDevices: [AudioDevice] = AudioManager.shared
@@ -324,6 +327,7 @@ public final class Conversation: ObservableObject, RoomDelegate {
         // Don't reset isMuted - it should reflect actual room state
         agentState = .listening
         pendingToolCalls.removeAll()
+        agentToolResponses.removeAll()
         conversationInitTask?.cancel()
     }
 
@@ -346,6 +350,7 @@ public final class Conversation: ObservableObject, RoomDelegate {
         // Clear conversation state
         messages.removeAll()
         pendingToolCalls.removeAll()
+        agentToolResponses.removeAll()
 
         // Reset agent state
         agentState = .listening
@@ -479,9 +484,8 @@ public final class Conversation: ObservableObject, RoomDelegate {
             break
 
         case let .agentToolResponse(toolResponse):
-            // Agent tool response is available in the event stream
-            // This can be used to track tool executions by the agent
-            break
+            // Capture agent tool responses for tracking and debugging
+            agentToolResponses.append(toolResponse)
         }
     }
 


### PR DESCRIPTION
 _What's changed_

- Added @Published public private(set) var agentToolResponses: [AgentToolResponseEvent] = [] property to Conversation class for tracking agent tool responses
- Updated the .agentToolResponse event handler to capture and store tool response events
- Added cleanup logic in resetFlags() and cleanupPreviousConversation() to clear stored responses on reset/disconnect

_Why_

This extends the previous PR that added support for parsing agent_tool_response events. While the previous PR fixed the parsing errors and handled the events internally, this update exposes the agent tool responses to SDK users through a published property, allowing them to observe and track when agents execute tools.

_Usage_

SDK users can now observe agent tool executions:
```
conversation.$agentToolResponses
    .sink { responses in
        for response in responses {
            print("Agent executed tool: \(response.toolName)")
            if response.isError {
                print("Tool execution failed")
            }
        }
    }
    .store(in: &cancellables)
```

_Testing_

The existing test coverage for AgentToolResponseEvent parsing validates the underlying functionality. SDK users can now access these events through the published property for their own tracking and debugging needs.