### PR TITLE
Add conversationId to Conversation

### DIFF
--- a/Sources/ElevenLabs/Conversation.swift
+++ b/Sources/ElevenLabs/Conversation.swift
@@ -17,6 +17,7 @@ public final class Conversation: ObservableObject, RoomDelegate {
     @Published public private(set) var state: ConversationState = .idle
     @Published public private(set) var messages: [Message] = []
     @Published public private(set) var agentState: AgentState = .listening
+    @Published public private(set) var conversationId: String?
     @Published public private(set) var isMuted: Bool = true // Start as true, will be updated based on actual state
 
     /// Stream of client tool calls that need to be executed by the app
@@ -349,6 +350,7 @@ public final class Conversation: ObservableObject, RoomDelegate {
 
         // Reset agent state
         agentState = .listening
+        conversationId = nil
         isMuted = true // Start muted, will be updated based on actual room state
 
         print("[ElevenLabs] Previous conversation state cleaned up for fresh Room")
@@ -468,8 +470,9 @@ public final class Conversation: ObservableObject, RoomDelegate {
             speakingTimer?.cancel()
             agentState = .listening
 
-        case .conversationMetadata:
+        case let .conversationMetadata(e):
             // Don't change agent state on metadata
+            conversationId = e.conversationId
             break
 
         case let .ping(p):


### PR DESCRIPTION
_What's changed_

Many of the Elevenlabs apis expose `conversationId`, but this API does not.  This PR exposes that variable.

_Why_

The `conversationId` is useful.  We observe it when a conversation is started.  We have a web hook registered with Elevenlabs, and when that fires, we use the `conversationId` in the web hook payload to correlate the conversation back to our data.

_Usage_

SDK users can now now use the `conversationId` when it is received:

```
            conversation.$conversationId
                .sink { conversationId in
                    print("Conversation id \(String(describing: conversationId))")
                }
```

_Testing_

I looked through the tests and was unable to find a good place to add test coverage.  The most simple test would be to update an integration test, but I couldn't find anything suitable for that.  The change could be tested with some heavy mocking, but I didn't see any tests that covered similar existing behavior, like `$state` changes on the `Conversation` class.  I ran all of the tests with a breakpoint on `Conversation.handleIncomingEvent` and nothing exercises that method.

The change itself is very simple though.
