### PR TITLE
Fix: update RoomDelegate signature for LiveKit 2.8.x

### DIFF
--- a/Sources/ElevenLabs/Conversation.swift
+++ b/Sources/ElevenLabs/Conversation.swift
@@ -808,7 +808,11 @@ private final class ConversationDataDelegate: RoomDelegate, @unchecked Sendable 
     }
 
     func room(
-        _: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String
+        _: Room,
+        participant _: RemoteParticipant?,
+        didReceiveData data: Data,
+        forTopic _: String,
+        encryptionType _: EncryptionType
     ) {
         onData(data)
     }
@@ -944,3 +948,4 @@ public enum ConversationError: LocalizedError, Sendable, Equatable {
         }
     }
 }
+

--- a/Sources/ElevenLabs/Networking/ConnectionManager.swift
+++ b/Sources/ElevenLabs/Networking/ConnectionManager.swift
@@ -273,7 +273,13 @@ private final class DataChannelDelegate: RoomDelegate, @unchecked Sendable {
 
     // MARK: – Delegate
 
-    nonisolated func room(_: Room, participant: RemoteParticipant?, didReceiveData data: Data, forTopic _: String) {
+    nonisolated func room(
+        _: Room,
+        participant: RemoteParticipant?,
+        didReceiveData data: Data,
+        forTopic _: String,
+        encryptionType _: EncryptionType
+    ) {
         // Only process messages from the agent
         guard participant != nil else {
             print("[DataChannelReceiver] Received data but no participant, ignoring")
@@ -306,3 +312,4 @@ private final class DataChannelDelegate: RoomDelegate, @unchecked Sendable {
 extension ConversationError {
     static let notImplemented = ConversationError.authenticationFailed("Not implemented yet")
 }
+

--- a/Sources/ElevenLabs/Networking/Receive/DataChannelReceiver.swift
+++ b/Sources/ElevenLabs/Networking/Receive/DataChannelReceiver.swift
@@ -66,7 +66,11 @@ actor DataChannelReceiver: MessageReceiver {
 @available(macOS 11.0, iOS 14.0, *)
 extension DataChannelReceiver: RoomDelegate {
     nonisolated func room(
-        _: Room, participant: RemoteParticipant?, didReceiveData data: Data, forTopic _: String
+        _: Room,
+        participant: RemoteParticipant?,
+        didReceiveData data: Data,
+        forTopic _: String,
+        encryptionType _: EncryptionType
     ) {
         // Only process messages from the agent
         guard participant != nil else {


### PR DESCRIPTION
This patch updates method signatures conforming to the latest RoomDelegate protocol changes introduced in LiveKit Swift SDK 2.8.x.

Specifically:

- Updated `room(_:participant:didReceiveData:forTopic:)` to →
`room(_:participant:didReceiveData:forTopic:encryptionType:)
`
- Applied consistent updates across `DataChannelReceiver`, `ConnectionManager`, and `Conversation` to align with the new delegate API.
