### PR TITLE
Update ios sdk for livekit breaking changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/livekit/client-sdk-swift.git", from: "2.6.1"),
+        .package(url: "https://github.com/livekit/client-sdk-swift.git", exact: "2.8.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.6.3"),
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.3"),
     ],

--- a/Sources/ElevenLabs/Conversation.swift
+++ b/Sources/ElevenLabs/Conversation.swift
@@ -815,7 +815,7 @@ private final class ConversationDataDelegate: RoomDelegate, @unchecked Sendable 
     }
 
     func room(
-        _: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String,
+        _: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String, encryptionType _: EncryptionType,
     ) {
         onData(data)
     }

--- a/Sources/ElevenLabs/Networking/ConnectionManager.swift
+++ b/Sources/ElevenLabs/Networking/ConnectionManager.swift
@@ -273,7 +273,7 @@ private final class DataChannelDelegate: RoomDelegate, @unchecked Sendable {
 
     // MARK: – Delegate
 
-    nonisolated func room(_: Room, participant: RemoteParticipant?, didReceiveData data: Data, forTopic _: String) {
+    nonisolated func room(_: Room, participant: RemoteParticipant?, didReceiveData data: Data, forTopic _: String, encryptionType _: EncryptionType) {
         // Only process messages from the agent
         guard participant != nil else {
             print("[DataChannelReceiver] Received data but no participant, ignoring")

--- a/Sources/ElevenLabs/Networking/Receive/DataChannelReceiver.swift
+++ b/Sources/ElevenLabs/Networking/Receive/DataChannelReceiver.swift
@@ -66,7 +66,7 @@ actor DataChannelReceiver: MessageReceiver {
 @available(macOS 11.0, iOS 14.0, *)
 extension DataChannelReceiver: RoomDelegate {
     nonisolated func room(
-        _: Room, participant: RemoteParticipant?, didReceiveData data: Data, forTopic _: String,
+        _: Room, participant: RemoteParticipant?, didReceiveData data: Data, forTopic _: String, encryptionType _: EncryptionType,
     ) {
         // Only process messages from the agent
         guard participant != nil else {


### PR DESCRIPTION
Update LiveKit delegate method signature and pin LiveKit dependency to fix compilation errors due to a breaking change.

LiveKit updated its iOS library, introducing a breaking change where the `room(_:participant:didReceiveData:forTopic:)` method was renamed to include an `encryptionType` parameter. This PR updates the method signature across the codebase and pins the LiveKit version to `2.8.1` to prevent similar issues in the future.

---
<a href="https://cursor.com/background-agent?bcId=bc-72b9d2be-9047-4c33-a90e-d8b231340681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-72b9d2be-9047-4c33-a90e-d8b231340681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

