### PR TITLE
feat: support `agent_response_metadata`

### DIFF
--- a/Sources/ElevenLabs/Conversation.swift
+++ b/Sources/ElevenLabs/Conversation.swift
@@ -640,6 +640,9 @@ public final class Conversation: ObservableObject, RoomDelegate {
             // Handle agent response corrections
             options.onAgentResponseCorrection?(correction.originalAgentResponse, correction.correctedAgentResponse, correction.eventId)
 
+        case let .agentResponseMetadata(metadata):
+            options.onAgentResponseMetadata?(metadata.metadataData, metadata.eventId)
+
         case let .agentChatResponsePart(e):
             handleAgentChatResponsePart(e)
 
@@ -1244,6 +1247,9 @@ public struct ConversationOptions: Sendable {
     /// Called when an agent response is corrected.
     public var onAgentResponseCorrection: (@Sendable (_ original: String, _ corrected: String, _ eventId: Int) -> Void)?
 
+    /// Called when agent response metadata is received.
+    public var onAgentResponseMetadata: (@Sendable (_ metadataData: Data, _ eventId: Int) -> Void)?
+
     /// Called for each user transcript event emitted by the server.
     public var onUserTranscript: (@Sendable (_ text: String, _ eventId: Int) -> Void)?
 
@@ -1288,6 +1294,7 @@ public struct ConversationOptions: Sendable {
         onSpeechActivity: (@Sendable (SpeechActivityEvent) -> Void)? = nil,
         onAgentResponse: (@Sendable (_ text: String, _ eventId: Int) -> Void)? = nil,
         onAgentResponseCorrection: (@Sendable (_ original: String, _ corrected: String, _ eventId: Int) -> Void)? = nil,
+        onAgentResponseMetadata: (@Sendable (_ metadataData: Data, _ eventId: Int) -> Void)? = nil,
         onUserTranscript: (@Sendable (_ text: String, _ eventId: Int) -> Void)? = nil,
         onConversationMetadata: (@Sendable (ConversationMetadataEvent) -> Void)? = nil,
         onAgentToolResponse: (@Sendable (AgentToolResponseEvent) -> Void)? = nil,
@@ -1314,6 +1321,7 @@ public struct ConversationOptions: Sendable {
         self.onSpeechActivity = onSpeechActivity
         self.onAgentResponse = onAgentResponse
         self.onAgentResponseCorrection = onAgentResponseCorrection
+        self.onAgentResponseMetadata = onAgentResponseMetadata
         self.onUserTranscript = onUserTranscript
         self.onConversationMetadata = onConversationMetadata
         self.onAgentToolResponse = onAgentToolResponse

--- a/Sources/ElevenLabs/Networking/Receive/DataChannelReceiver.swift
+++ b/Sources/ElevenLabs/Networking/Receive/DataChannelReceiver.swift
@@ -92,6 +92,9 @@ extension DataChannelReceiver: RoomDelegate {
             case let .agentResponseCorrection(correctionEvent):
                 handleAgentResponseCorrection(correctionEvent)
 
+            case let .agentResponseMetadata(metadataEvent):
+                handleAgentResponseMetadata(metadataEvent)
+
             case let .agentChatResponsePart(chatResponsePartEvent):
                 handleAgentChatResponsePart(chatResponsePartEvent)
 
@@ -168,6 +171,11 @@ extension DataChannelReceiver: RoomDelegate {
         yield(message: message)
         logger.debug(
             "Agent correction: \(event.originalAgentResponse) -> \(event.correctedAgentResponse)")
+    }
+
+    private func handleAgentResponseMetadata(_ event: AgentResponseMetadataEvent) {
+        logger.info("Agent response metadata received (Event ID: \(event.eventId))")
+        // Agent response metadata is available in the event stream
     }
 
     private func handleUserTranscript(_ event: UserTranscriptEvent) {

--- a/Sources/ElevenLabs/Protocol/EventParser.swift
+++ b/Sources/ElevenLabs/Protocol/EventParser.swift
@@ -44,6 +44,18 @@ enum EventParser {
                 ))
             }
 
+        case "agent_response_metadata":
+            if let event = json["agent_response_metadata_event"] as? [String: Any],
+               let eventId = event["event_id"] as? Int,
+               let metadata = event["metadata"] as? [String: Any],
+               let metadataData = try? JSONSerialization.data(withJSONObject: metadata)
+            {
+                return .agentResponseMetadata(AgentResponseMetadataEvent(
+                    eventId: eventId,
+                    metadataData: metadataData
+                ))
+            }
+
         case "audio":
             if let event = json["audio_event"] as? [String: Any],
                let eventId = event["event_id"] as? Int

--- a/Sources/ElevenLabs/Protocol/IncomingEvents.swift
+++ b/Sources/ElevenLabs/Protocol/IncomingEvents.swift
@@ -8,6 +8,7 @@ public enum IncomingEvent: Sendable {
     case tentativeUserTranscript(TentativeUserTranscriptEvent)
     case agentResponse(AgentResponseEvent)
     case agentResponseCorrection(AgentResponseCorrectionEvent)
+    case agentResponseMetadata(AgentResponseMetadataEvent)
     case agentChatResponsePart(AgentChatResponsePartEvent)
     case audio(AudioEvent)
     case interruption(InterruptionEvent)
@@ -53,6 +54,12 @@ public struct AgentResponseCorrectionEvent: Sendable {
     public let originalAgentResponse: String
     public let correctedAgentResponse: String
     public let eventId: Int
+}
+
+/// Agent response metadata
+public struct AgentResponseMetadataEvent: Sendable {
+    public let eventId: Int
+    public let metadataData: Data
 }
 
 public struct AgentChatResponsePartEvent: Sendable {

--- a/Tests/ElevenLabsTests/Tests/EventParserTests.swift
+++ b/Tests/ElevenLabsTests/Tests/EventParserTests.swift
@@ -277,4 +277,26 @@ final class EventParserTests: XCTestCase {
         XCTAssertEqual(part.text, "Test")
         XCTAssertEqual(part.type, .delta)
     }
+
+    func testParseAgentResponseMetadataEvent() throws {
+        let json = """
+        {
+            "type": "agent_response_metadata",
+            "agent_response_metadata_event": {
+                "event_id": 456,
+                "metadata": {"custom_field": "custom_value"}
+            }
+        }
+        """.data(using: .utf8)!
+
+        let event = try EventParser.parseIncomingEvent(from: json)
+
+        guard case let .agentResponseMetadata(metadata) = event else {
+            XCTFail("Expected agentResponseMetadata event")
+            return
+        }
+
+        XCTAssertEqual(metadata.eventId, 456)
+        XCTAssertFalse(metadata.metadataData.isEmpty)
+    }
 }


### PR DESCRIPTION
Add `agent_response_metadata` event with callback to receive custom metadata from the agent.