### PR TITLE
Fix typo in README: conversatoin -> conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ let conversation = try await ElevenLabs.startConversation(
 
 ```swift
 // Option 1: Direct method (recommended)
-// Get a conversatoin token from your backend (never store API keys in your app)
+// Get a conversation token from your backend (never store API keys in your app)
 let token = try await fetchConversationToken()
 
 let conversation = try await ElevenLabs.startConversation(


### PR DESCRIPTION
## Summary

Fixed a typo in the README.md documentation:
- Changed "conversatoin" to "conversation" in the Private Agents with Conversation Token section (line 234)

## Type of Change
- Documentation fix

## Checklist
- [x] Spelling/grammar correction
- [x] No functional changes