### PR TITLE
Fix documentation: use correct enum case name .connectingRoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ let config = ConversationConfig(
             print("Not started")
         case .resolvingToken:
             print("Fetching authentication token...")
-        case .connectingToRoom:
+        case .connectingRoom:
             print("Connecting to LiveKit room...")
         case .waitingForAgent(let timeout):
             print("Waiting for agent (timeout: \(timeout)s)...")


### PR DESCRIPTION
## Summary

Fixed incorrect enum case name in README documentation for `ConversationStartupState`:
- Changed `.connectingToRoom` to `.connectingRoom` to match the actual enum definition

## Issue
Fixes #127

## Type of Change
- Documentation fix

## Details
The README showed the incorrect case name `.connectingToRoom` in the example code for monitoring conversation startup state. The actual enum case is `.connectingRoom` (without "To").

## Checklist
- [x] Documentation updated to match code
- [x] No functional changes