### PR TITLE
Fix README: remove non-existent expectsResponse property

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,23 +178,18 @@ private func handleToolCall(_ toolCall: ClientToolCallEvent) async {
             parameters: parameters
         )
 
-        if toolCall.expectsResponse {
-            try await conversation?.sendToolResult(
-                for: toolCall.toolCallId,
-                result: result
-            )
-        } else {
-            conversation?.markToolCallCompleted(toolCall.toolCallId)
-        }
+        // Send the tool result back to the agent
+        try await conversation?.sendToolResult(
+            for: toolCall.toolCallId,
+            result: result
+        )
     } catch {
         // Handle tool execution errors
-        if toolCall.expectsResponse {
-            try? await conversation?.sendToolResult(
-                for: toolCall.toolCallId,
-                result: ["error": error.localizedDescription],
-                isError: true
-            )
-        }
+        try? await conversation?.sendToolResult(
+            for: toolCall.toolCallId,
+            result: ["error": error.localizedDescription],
+            isError: true
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Fixed incorrect example code in the README that referenced a non-existent property:
- Removed references to `toolCall.expectsResponse` which doesn't exist in `ClientToolCallEvent`
- Simplified the tool call handling example to always send tool results back to the agent

## Issue
This addresses part of the documentation concerns mentioned in #99 where the README contains examples that don't match the actual API.

## Type of Change
- Documentation fix

## Details
The README showed an example checking `toolCall.expectsResponse`, but this property doesn't exist in the `ClientToolCallEvent` struct (verified in `Sources/ElevenLabs/Protocol/IncomingEvents.swift` and the AsyncAPI schema).

The simplified example now:
- Always sends tool results using `sendToolResult()`
- Sends error results when tool execution fails
- Removed the conditional `markToolCallCompleted()` branch

This matches the actual struct definition and provides clearer guidance to SDK users.

## Checklist
- [x] Verified property doesn't exist in source code
- [x] Checked AsyncAPI schema
- [x] Simplified example code
- [x] No functional changes to SDK code