### PR TITLE
Improve cleanup on deallocation for `ConnectionManager` & `DataChannelReceiver`

### DIFF
--- a/Sources/ElevenLabs/Internal/Networking/ConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/ConnectionManager.swift
@@ -318,6 +318,12 @@ extension ConnectionManager {
             self.onDisconnected = onDisconnected
         }
 
+        deinit {
+            // Safety net: cancel timeout when delegate is deallocated without
+            // going through reset() (e.g. Conversation deallocated directly).
+            timeoutTask?.cancel()
+        }
+
         // MARK: – RoomDelegate
 
         nonisolated func roomDidConnect(_ room: Room) {

--- a/Sources/ElevenLabs/Internal/Networking/Receive/DataChannelReceiver.swift
+++ b/Sources/ElevenLabs/Internal/Networking/Receive/DataChannelReceiver.swift
@@ -81,7 +81,7 @@ extension DataChannelReceiver: RoomDelegate {
             return
         }
         Task { [weak self] in
-            // Use weak self to avoid retaining the actor and leaking Tasks
+            // Avoid processing events after the receiver has been deallocated
             await self?.handleDataMessage(data)
         }
     }

--- a/Sources/ElevenLabs/Internal/Networking/Receive/DataChannelReceiver.swift
+++ b/Sources/ElevenLabs/Internal/Networking/Receive/DataChannelReceiver.swift
@@ -51,7 +51,7 @@ actor DataChannelReceiver: MessageReceiver {
 
         continuation.onTermination = { [weak self] _ in
             Task { [weak self] in
-                await self?.handleMessageStreamTermination()
+                await self?.handleEventStreamTermination()
             }
         }
 

--- a/Sources/ElevenLabs/Internal/Networking/Receive/DataChannelReceiver.swift
+++ b/Sources/ElevenLabs/Internal/Networking/Receive/DataChannelReceiver.swift
@@ -34,7 +34,9 @@ actor DataChannelReceiver: MessageReceiver {
 
         continuation.onTermination = { [weak self] _ in
             Task { [weak self] in
-                await self?.cleanup()
+                guard let self else { return }
+                await self.cleanup()
+                self.room.remove(delegate: self) // Unregister from the room to stop receiving messages and prevent memory leaks
             }
         }
 
@@ -51,6 +53,8 @@ actor DataChannelReceiver: MessageReceiver {
     // MARK: - Private Methods
 
     private func cleanup() {
+        messageContinuation?.finish() // Finish the stream to avoid memory leaks and signal termination
+        eventContinuation?.finish()
         messageContinuation = nil
         eventContinuation = nil
     }
@@ -76,8 +80,9 @@ extension DataChannelReceiver: RoomDelegate {
             logger.debug("Received data but no participant, ignoring")
             return
         }
-        Task {
-            await handleDataMessage(data)
+        Task { [weak self] in
+            // Use weak self to avoid retaining the actor and leaking Tasks
+            await self?.handleDataMessage(data)
         }
     }
 

--- a/Sources/ElevenLabs/Internal/Networking/Receive/DataChannelReceiver.swift
+++ b/Sources/ElevenLabs/Internal/Networking/Receive/DataChannelReceiver.swift
@@ -90,7 +90,7 @@ extension DataChannelReceiver: RoomDelegate {
             return
         }
         Task {
-            await self.handleDataMessage(data)
+            await handleDataMessage(data)
         }
     }
 

--- a/Sources/ElevenLabs/Internal/Networking/Receive/DataChannelReceiver.swift
+++ b/Sources/ElevenLabs/Internal/Networking/Receive/DataChannelReceiver.swift
@@ -22,21 +22,22 @@ actor DataChannelReceiver: MessageReceiver {
     }
 
     deinit {
+        // Finish streams first, then unregister from room
+        messageContinuation?.finish()
+        eventContinuation?.finish()
         room.delegates.remove(delegate: self)
     }
 
     // MARK: - Public API
 
     /// Stream of chat messages (agent responses and user transcripts)
-    func messages() async throws -> AsyncStream<ReceivedMessage> {
+    func messages() async -> AsyncStream<ReceivedMessage> {
         let (stream, continuation) = AsyncStream<ReceivedMessage>.makeStream()
         messageContinuation = continuation
 
         continuation.onTermination = { [weak self] _ in
             Task { [weak self] in
-                guard let self else { return }
-                await self.cleanup()
-                self.room.remove(delegate: self) // Unregister from the room to stop receiving messages and prevent memory leaks
+                await self?.handleMessageStreamTermination()
             }
         }
 
@@ -47,15 +48,23 @@ actor DataChannelReceiver: MessageReceiver {
     func events() async -> AsyncStream<IncomingEvent> {
         let (stream, continuation) = AsyncStream<IncomingEvent>.makeStream()
         eventContinuation = continuation
+
+        continuation.onTermination = { [weak self] _ in
+            Task { [weak self] in
+                await self?.handleMessageStreamTermination()
+            }
+        }
+
         return stream
     }
 
     // MARK: - Private Methods
 
-    private func cleanup() {
-        messageContinuation?.finish() // Finish the stream to avoid memory leaks and signal termination
-        eventContinuation?.finish()
+    private func handleMessageStreamTermination() {
         messageContinuation = nil
+    }
+
+    private func handleEventStreamTermination() {
         eventContinuation = nil
     }
 
@@ -80,9 +89,8 @@ extension DataChannelReceiver: RoomDelegate {
             logger.debug("Received data but no participant, ignoring")
             return
         }
-        Task { [weak self] in
-            // Avoid processing events after the receiver has been deallocated
-            await self?.handleDataMessage(data)
+        Task {
+            await self.handleDataMessage(data)
         }
     }
 


### PR DESCRIPTION
Hey team 👋

While exploring the SDK, I found a few small improvements around `ConnectionManager` and `DataChannelReceiver`:

- **ConnectionManager:** Cancel the timeout and polling tasks on deinit. While this is mostly an edge case (e.g., prematurely closed conversations), it helps avoid leaving tasks alive after deallocation.
- **DataChannelReceiver:**
  - Finish the `AsyncStream` continuations on `deinit` to ensure streams are cleaned up. Without this, the actor could be deallocated while streams are still producing values with no consumers, which could lead to memory leaks.
  - `messages()` was marked as `throws`, but it doesn’t actually throw, so I removed the `throws`.

Small cleanup, but helps make the SDK safer and a bit more consistent!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup focused on deallocation behavior; main impact is earlier termination of AsyncStreams and cancelling a grace-timeout task, with minimal behavioral change outside edge-case lifecycle paths.
> 
> **Overview**
> Improves lifecycle cleanup in networking components to avoid leaving work running after deallocation.
> 
> `ConnectionManager.ReadyDelegate` now cancels its grace-timeout `Task` in `deinit` as a safety net when teardown doesn’t go through `reset()`.
> 
> `DataChannelReceiver` now *finishes* its message/event `AsyncStream` continuations on `deinit`, adds termination handling for the `events()` stream, and removes the unused `throws` from `messages()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3716e69a36e43bd0c4a65604ff7050040ff9b24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->