### PR TITLE
feat: surface server errors through `onError`

### DIFF
--- a/Sources/ElevenLabs/Internal/Conversation/Conversation+Events.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/Conversation+Events.swift
@@ -108,9 +108,9 @@ extension Conversation {
             // ASR initiation metadata is available in the event stream
             break
 
-        case .error:
-            logger.error("Received error event from server")
-            // Error events are available in the event stream
+        case let .error(errorEvent):
+            logger.error("Received error event from server: code=\(errorEvent.code), message=\(errorEvent.message ?? "none")")
+            options.onError?(.serverError(errorEvent))
         }
     }
 

--- a/Sources/ElevenLabs/Internal/Utilities/EventParser.swift
+++ b/Sources/ElevenLabs/Internal/Utilities/EventParser.swift
@@ -269,8 +269,14 @@ struct EventParser: EventParsable {
             }
 
         case "error":
-            // Skip for now as requested
-            break
+            if let event = json["error_event"] as? [String: Any] {
+                let code = event["code"] as? Int ?? 1011
+                let message = event["message"] as? String
+                return .error(ErrorEvent(code: code, message: message))
+            }
+            let code = json["code"] as? Int ?? 1011
+            let message = json["message"] as? String
+            return .error(ErrorEvent(code: code, message: message))
 
         default:
             throw EventParseError.unknownEventType(type)

--- a/Sources/ElevenLabs/Public/Conversation/ConversationError.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationError.swift
@@ -8,6 +8,7 @@ public enum ConversationError: LocalizedError, Sendable, Equatable {
     case agentTimeout
     case microphoneToggleFailed(String) // Store error description instead of Error for Equatable
     case localNetworkPermissionRequired
+    case serverError(ErrorEvent)
 
     /// Helper methods to create errors with Error types
     public static func connectionFailed(_ error: Error) -> ConversationError {
@@ -27,6 +28,7 @@ public enum ConversationError: LocalizedError, Sendable, Equatable {
         case .agentTimeout: "Agent did not join in time."
         case let .microphoneToggleFailed(description): "Failed to toggle microphone: \(description)"
         case .localNetworkPermissionRequired: "Local Network permission is required."
+        case let .serverError(event): "Server error (\(event.code)): \(event.message ?? "unknown")"
         }
     }
 }

--- a/Sources/ElevenLabs/Public/ElevenLabs/Events/IncomingEvents.swift
+++ b/Sources/ElevenLabs/Public/ElevenLabs/Events/IncomingEvents.swift
@@ -190,7 +190,13 @@ public struct ASRInitiationMetadataEvent: Sendable {
     }
 }
 
-/// Error event placeholder
-public struct ErrorEvent: Sendable {
-    // Placeholder for future error event fields
+//// Server error event with code and message.
+public struct ErrorEvent: Sendable, Equatable {
+    public let code: Int
+    public let message: String?
+
+    public init(code: Int, message: String? = nil) {
+        self.code = code
+        self.message = message
+    }
 }


### PR DESCRIPTION
Server error events were previously dropped. Now surfaced through `onError` with a new `.serverError(ErrorEvent)` case. Example callback in `ConversationConfig`:
```swift
onError: { error in
    switch error {
    case .serverError(let event):
        print("❌ Server error (\(event.code)): \(event.message ?? "unknown")")
    case .connectionFailed(let desc):
        print("❌ Connection failed: \(desc)")
    case .authenticationFailed(let msg):
        print("❌ Auth failed: \(msg)")
    case .agentTimeout:
        print("❌ Agent didn't connect in time")
    case .localNetworkPermissionRequired:
        print("❌ Enable Local Network permission in Settings")
    case .notConnected:
        print("❌ Not connected")
    case .alreadyActive:
        print("❌ Already active")
    case .microphoneToggleFailed(let desc):
        print("❌ Mic toggle failed: \(desc)")
    @unknown default:
        print("❌ Unknown error: \(error.localizedDescription)")
    }
},
```

