### PR TITLE
fix: Skip audio hardware initialization in text-only mode

### DIFF
--- a/Sources/ElevenLabs/Public/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Conversation.swift
@@ -115,9 +115,7 @@ public final class Conversation: ObservableObject, RoomDelegate {
         self.options = options
         // Temporary logger until dependencies are resolved
         logger = SDKLogger(logLevel: ElevenLabs.Global.shared.configuration.logLevel)
-        if !options.conversationOverrides.textOnly {
-            setupAudioManager()
-        }
+        setupAudioManager()
     }
 
     init(
@@ -128,12 +126,11 @@ public final class Conversation: ObservableObject, RoomDelegate {
         dependenciesTask = nil
         self.options = options
         logger = dependencyProvider.logger
-        if !options.conversationOverrides.textOnly {
-            setupAudioManager()
-        }
+        setupAudioManager()
     }
 
     private func setupAudioManager() {
+        guard !options.conversationOverrides.textOnly else { return }
         let manager = ConversationAudioManager(logger: logger)
         manager.onDevicesChanged = { [weak self] devices in
             self?.audioDevices = devices
@@ -200,12 +197,10 @@ public final class Conversation: ObservableObject, RoomDelegate {
         activeContext = ["agentId": currentAgentId]
         logger.info("Starting conversation", context: activeContext)
 
-        if !options.conversationOverrides.textOnly {
-            if audioManager == nil {
-                setupAudioManager()
-            }
-            await audioManager?.configure(with: options)
+        if audioManager == nil {
+            setupAudioManager()
         }
+        await audioManager?.configure(with: options)
         options.onCanSendFeedbackChange?(false)
 
         setupAgentStateManager()

--- a/Sources/ElevenLabs/Public/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Conversation.swift
@@ -45,10 +45,8 @@ public final class Conversation: ObservableObject, RoomDelegate {
     @Published public internal(set) var latestAudioEvent: AudioEvent?
 
     /// Device lists (optional to expose; keep `internal` if you don't want them public)
-    @Published public internal(set) var audioDevices: [AudioDevice] = AudioManager.shared
-        .inputDevices
-    @Published public internal(set) var selectedAudioDeviceID: String = AudioManager.shared
-        .inputDevice.deviceId
+    @Published public internal(set) var audioDevices: [AudioDevice] = []
+    @Published public internal(set) var selectedAudioDeviceID: String = ""
 
     /// Track the current streaming message for chat response parts
     var currentStreamingMessage: Message?
@@ -117,7 +115,9 @@ public final class Conversation: ObservableObject, RoomDelegate {
         self.options = options
         // Temporary logger until dependencies are resolved
         logger = SDKLogger(logLevel: ElevenLabs.Global.shared.configuration.logLevel)
-        setupAudioManager()
+        if !options.conversationOverrides.textOnly {
+            setupAudioManager()
+        }
     }
 
     init(
@@ -128,7 +128,9 @@ public final class Conversation: ObservableObject, RoomDelegate {
         dependenciesTask = nil
         self.options = options
         logger = dependencyProvider.logger
-        setupAudioManager()
+        if !options.conversationOverrides.textOnly {
+            setupAudioManager()
+        }
     }
 
     private func setupAudioManager() {
@@ -198,7 +200,12 @@ public final class Conversation: ObservableObject, RoomDelegate {
         activeContext = ["agentId": currentAgentId]
         logger.info("Starting conversation", context: activeContext)
 
-        await audioManager?.configure(with: options)
+        if !options.conversationOverrides.textOnly {
+            if audioManager == nil {
+                setupAudioManager()
+            }
+            await audioManager?.configure(with: options)
+        }
         options.onCanSendFeedbackChange?(false)
 
         setupAgentStateManager()

--- a/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
+++ b/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
@@ -173,9 +173,10 @@ public enum ElevenLabs {
         auth: ElevenLabsConfiguration,
         config: ConversationConfig = .init()
     ) async throws -> Conversation {
-        let conversation = createConversation()
+        let options = config.toConversationOptions()
+        let conversation = createConversation(options: options)
         try await conversation.startConversation(
-            auth: auth, options: config.toConversationOptions()
+            auth: auth, options: options
         )
         return conversation
     }
@@ -184,9 +185,9 @@ public enum ElevenLabs {
 
     /// Creates a new Conversation instance with proper dependency injection.
     @MainActor
-    private static func createConversation() -> Conversation {
+    private static func createConversation(options: ConversationOptions = .default) -> Conversation {
         let depsTask = Task { Dependencies.shared }
-        return Conversation(dependencies: depsTask)
+        return Conversation(dependencies: depsTask, options: options)
     }
 
     // MARK: - Re-exports


### PR DESCRIPTION
When textOnly is true, the SDK no longer eagerly initializes ConversationAudioManager or accesses AudioManager.shared, avoiding unnecessary microphone permission prompts and audio hardware setup.

Audio manager is now created lazily — only when a voice conversation actually starts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conversation startup and audio-device initialization timing, which could impact microphone/device selection behavior and voice-call setup if regressions slip in.
> 
> **Overview**
> Prevents audio hardware/device access when `conversationOverrides.textOnly` is enabled by skipping `ConversationAudioManager` setup and defaulting `audioDevices`/`selectedAudioDeviceID` to empty values.
> 
> Makes audio initialization *lazy*: if a `Conversation` was created in text-only mode, `startConversation` now creates/configures the audio manager only when needed, and `ElevenLabs.startConversation` passes options into the `Conversation` initializer so the text-only override is available before any setup runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06ab5b7ffbcf01008acd45f576055135ab93d4a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->