### PR TITLE
Attempt to limit background noise detection in software muted VAD

### DIFF
--- a/Sources/ElevenLabs/Internal/Conversation/ConversationAudioManager.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/ConversationAudioManager.swift
@@ -138,7 +138,12 @@ final class ConversationAudioManager {
             return
         }
 
-        softwareMuteProcessor = SoftwareMuteProcessor(onMutedSpeech: options.audioConfiguration?.onMutedSpeech)
+        let audioConfig = options.audioConfiguration
+        softwareMuteProcessor = SoftwareMuteProcessor(
+            onMutedSpeech: audioConfig?.onMutedSpeech,
+            mutedSpeechThresholdInDb: audioConfig?.mutedSpeechThreshold ?? -35,
+            mutedSpeechThrottleInSeconds: 3.0
+        )
         AudioManager.shared.capturePostProcessingDelegate = softwareMuteProcessor
     }
 

--- a/Sources/ElevenLabs/Internal/Utilities/SoftwareMuteProcessor.swift
+++ b/Sources/ElevenLabs/Internal/Utilities/SoftwareMuteProcessor.swift
@@ -7,13 +7,23 @@
 
 import Accelerate
 import CoreMedia
+import Foundation
 import LiveKit
 import LiveKitWebRTC
 
 final class SoftwareMuteProcessor: NSObject, @unchecked Sendable, AudioCustomProcessingDelegate {
+    private enum Hangover {
+        static let buffersAboveToConfirm = 4
+        static let buffersBelowToClear = 3
+    }
+
     private var lock = os_unfair_lock_s()
     private var isMuted: Bool = false
     private var lastNotificationTime: Date = .distantPast
+
+    private var consecutiveAboveCount: Int = 0
+    private var consecutiveBelowCount: Int = 0
+    private var hangoverLatched: Bool = false
 
     private let onMutedSpeech: (@Sendable (MutedSpeechEvent) -> Void)?
     private let mutedSpeechThresholdInDb: Float
@@ -31,6 +41,11 @@ final class SoftwareMuteProcessor: NSObject, @unchecked Sendable, AudioCustomPro
 
     func setMuted(_ muted: Bool) {
         os_unfair_lock_lock(&lock)
+        if isMuted != muted {
+            consecutiveAboveCount = 0
+            consecutiveBelowCount = 0
+            hangoverLatched = false
+        }
         isMuted = muted
         os_unfair_lock_unlock(&lock)
     }
@@ -38,7 +53,6 @@ final class SoftwareMuteProcessor: NSObject, @unchecked Sendable, AudioCustomPro
     func audioProcessingProcess(audioBuffer: LKAudioBuffer) {
         os_unfair_lock_lock(&lock)
         let currentlyMuted = isMuted
-        let lastTime = lastNotificationTime
         os_unfair_lock_unlock(&lock)
 
         guard currentlyMuted else { return }
@@ -59,15 +73,40 @@ final class SoftwareMuteProcessor: NSObject, @unchecked Sendable, AudioCustomPro
         }
         let averageRMS = totalRMS / Float(max(audioBuffer.channels, 1))
         let db = 20 * log10(max(averageRMS, 1e-6))
-        if db > mutedSpeechThresholdInDb {
+
+        let levelActive = db > mutedSpeechThresholdInDb
+
+        var shouldFire = false
+        var fireLevel: Float = 0
+        os_unfair_lock_lock(&lock)
+        if levelActive {
+            consecutiveBelowCount = 0
+            consecutiveAboveCount += 1
+            if consecutiveAboveCount >= Hangover.buffersAboveToConfirm {
+                hangoverLatched = true
+            }
+        } else {
+            consecutiveAboveCount = 0
+            consecutiveBelowCount += 1
+            if consecutiveBelowCount >= Hangover.buffersBelowToClear {
+                hangoverLatched = false
+                consecutiveBelowCount = 0
+            }
+        }
+
+        if hangoverLatched, levelActive {
             let now = Date()
-            if now.timeIntervalSince(lastTime) > mutedSpeechThrottleInSeconds {
-                os_unfair_lock_lock(&lock)
+            if now.timeIntervalSince(lastNotificationTime) > mutedSpeechThrottleInSeconds {
                 lastNotificationTime = now
-                os_unfair_lock_unlock(&lock)
-                DispatchQueue.main.async {
-                    self.onMutedSpeech?(.init(audioLevel: db))
-                }
+                shouldFire = true
+                fireLevel = db
+            }
+        }
+        os_unfair_lock_unlock(&lock)
+
+        if shouldFire {
+            DispatchQueue.main.async {
+                self.onMutedSpeech?(.init(audioLevel: fireLevel))
             }
         }
 

--- a/Sources/ElevenLabs/Public/Conversation/AudioPipelineConfiguration.swift
+++ b/Sources/ElevenLabs/Public/Conversation/AudioPipelineConfiguration.swift
@@ -38,7 +38,7 @@ public struct AudioPipelineConfiguration: Sendable {
     /// Use this to show "You're speaking while muted" indicators.
     public var onMutedSpeech: (@Sendable (MutedSpeechEvent) -> Void)?
 
-    /// Audio level in dB where speech is detected. Default: -30 dB.
+    /// Audio level in dB where speech is detected. Default: -35 dB (see `SoftwareMuteProcessor`).
     /// Increase to require louder speech, decrease for more sensitivity.
     public var mutedSpeechThreshold: Float?
 

--- a/Tests/ElevenLabsTests/Unit/SoftwareMuteProcessorTests.swift
+++ b/Tests/ElevenLabsTests/Unit/SoftwareMuteProcessorTests.swift
@@ -50,8 +50,44 @@ final class SoftwareMuteProcessorTests: XCTestCase {
         )
 
         processor.setMuted(true)
-        try processor.audioProcessingProcess(audioBuffer: loadBuffer(named: "spoken-audio"))
+        for _ in 0 ..< 4 {
+            try processor.audioProcessingProcess(audioBuffer: loadBuffer(named: "spoken-audio"))
+        }
         wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testSingleLoudBufferDoesNotFireWithDefaultHangover() throws {
+        let expectation = expectation(description: "should not fire on single buffer")
+        expectation.isInverted = true
+
+        let processor = SoftwareMuteProcessor(
+            onMutedSpeech: { _ in
+                expectation.fulfill()
+            },
+            mutedSpeechThrottleInSeconds: 0
+        )
+
+        processor.setMuted(true)
+        try processor.audioProcessingProcess(audioBuffer: loadBuffer(named: "spoken-audio"))
+        wait(for: [expectation], timeout: 0.5)
+    }
+
+    func testThreeLoudBuffersDoNotFireWithDefaultHangover() throws {
+        let expectation = expectation(description: "should not fire until 4 consecutive loud buffers")
+        expectation.isInverted = true
+
+        let processor = SoftwareMuteProcessor(
+            onMutedSpeech: { _ in
+                expectation.fulfill()
+            },
+            mutedSpeechThrottleInSeconds: 0
+        )
+
+        processor.setMuted(true)
+        for _ in 0 ..< 3 {
+            try processor.audioProcessingProcess(audioBuffer: loadBuffer(named: "spoken-audio"))
+        }
+        wait(for: [expectation], timeout: 0.5)
     }
 
     func testDoesNotChangeBufferedDataIfUnmuted() throws {


### PR DESCRIPTION
This establishes some baseline noise levels that we use to handle
the software muted VAD. This isn't a real VAD and just meant to
help user interfaces display "are you talking" style interfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes when `onMutedSpeech` fires during software mute and adds new stateful gating logic that could affect UI indicators or miss short utterances if tuned incorrectly.
> 
> **Overview**
> Improves software-mute “speaking while muted” detection by adding a simple *hangover* gate in `SoftwareMuteProcessor`, requiring multiple consecutive buffers above the dB threshold before firing and clearing after several quiet buffers, while keeping throttling behavior.
> 
> Updates `ConversationAudioManager` to pass the configurable `mutedSpeechThreshold` (defaulting to **-35 dB**) into the processor, adjusts public docs accordingly, and expands unit tests to cover the new “requires 4 consecutive loud buffers” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2298eee9dffada29cce9305c9e7e778373a4536b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->