### PR TITLE
chore: bump to version 3.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add the package via Swift Package Manager:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/elevenlabs/elevenlabs-swift-sdk.git", from: "3.1.2")
+    .package(url: "https://github.com/elevenlabs/elevenlabs-swift-sdk.git", from: "3.1.3")
 ]
 ```
 

--- a/Sources/ElevenLabs/Internal/Version.swift
+++ b/Sources/ElevenLabs/Internal/Version.swift
@@ -3,5 +3,5 @@
 import Foundation
 
 enum SDKVersion {
-    static let version = "3.1.2"
+    static let version = "3.1.3"
 }

--- a/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
+++ b/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
@@ -20,7 +20,7 @@ import LiveKit
 public enum ElevenLabs {
     // MARK: - Version
 
-    public static let version = "3.1.2"
+    public static let version = "3.1.3"
 
     // MARK: - Configuration
 

--- a/Tests/ElevenLabsTests/Unit/ElevenLabsSDKTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ElevenLabsSDKTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class ElevenLabsSDKTests: XCTestCase {
     func testSDKVersionExists() {
-        XCTAssertEqual(ElevenLabs.version, "3.1.2")
+        XCTAssertEqual(ElevenLabs.version, "3.1.3")
         XCTAssertFalse(ElevenLabs.version.isEmpty)
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a pure version bump with no behavioral or API changes beyond updating version strings and associated test expectations.
> 
> **Overview**
> Bumps the SDK from `3.1.2` to `3.1.3`, updating the published version constants (`ElevenLabs.version` and internal `SDKVersion.version`), the README SwiftPM install snippet, and the unit test that asserts the version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27233cef8f5b10c4d879b42520ff995516daf89e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->