### PR TITLE
docs: add Releasing section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,3 +248,15 @@ We love contributions!
 - **Patterns**: Adhere to Swift Concurrency best practices (Actors/MainActor).
 
 Explore our [Usage Documentation](Documentation/Usage.md) for more depth.
+
+---
+
+## Releasing
+
+To release a new version of the SDK, use the [Claude Code](https://docs.anthropic.com/en/docs/claude-code) release command:
+
+```bash
+claude /release <version>
+```
+
+This will update version strings, lint, run checks, open a PR, and (after merge) tag the release to make it available via [Swift Package Manager](https://www.swift.org/documentation/package-manager/).


### PR DESCRIPTION
## Summary
- Adds a "Releasing" section to the README documenting the `claude /release` command for SDK releases, mirroring the same section added to the Flutter SDK.

## Test plan
- [x] Verified the new section renders correctly in the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that doesn’t affect runtime behavior or APIs.
> 
> **Overview**
> Adds a new **Releasing** section to `README.md` documenting how to publish a new SDK version using the `claude /release <version>` command, including what automated steps it performs (version bumps, checks, PR creation, and tagging for Swift Package Manager).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 872edbb63f691ba565a08f5309bacdc3749c48c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->