### PR TITLE
Bump visionOS version and patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 xcuserdata/
 xcshareddata/
 Package.resolved
+*.bak

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .iOS(.v13),
         .macOS(.v10_15),
         .macCatalyst(.v14),
-        .visionOS(.v1),
+        .visionOS(.v26),
         .tvOS(.v17)
     ],
     products: [

--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -1,5 +1,5 @@
-// swift-tools-version:5.9
-// Swift 5.9+ (Xcode 15.0+)
+// swift-tools-version:6.2
+// Swift 6.2+ (Xcode 26.0+)
 
 import PackageDescription
 
@@ -9,7 +9,7 @@ let package = Package(
         .iOS(.v13),
         .macOS(.v10_15),
         .macCatalyst(.v14),
-        .visionOS(.v1),
+        .visionOS(.v26),
         .tvOS(.v17)
     ],
     products: [
@@ -49,7 +49,5 @@ let package = Package(
             ]
         )
     ],
-    swiftLanguageVersions: [
-        .v5
-    ]
+    swiftLanguageModes: [.v5]
 )

--- a/Sources/ElevenLabs/Internal/Version.swift
+++ b/Sources/ElevenLabs/Internal/Version.swift
@@ -3,5 +3,5 @@
 import Foundation
 
 enum SDKVersion {
-    static let version = "3.1.4"
+    static let version = "3.1.5"
 }


### PR DESCRIPTION
Fixes https://github.com/elevenlabs/elevenlabs-swift-sdk/issues/177

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an additional SwiftPM manifest for newer toolchains and bumps a version string, with no runtime logic changes.
> 
> **Overview**
> Adds an additional SwiftPM manifest `Package@swift-6.2.swift` for Swift 6.2/Xcode 26, raising the declared `visionOS` deployment target to `.v26` while keeping dependencies/targets aligned with the existing manifest.
> 
> Bumps `SDKVersion` from `3.1.4` to `3.1.5` and updates `.gitignore` to exclude `*.bak` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18805a1ae26de5398a1a32e103fddd8f01d176a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->