### PR TITLE
Fix messages

### DIFF
--- a/Sources/ElevenLabs/Internal/Conversation/Conversation+Events.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/Conversation+Events.swift
@@ -8,7 +8,7 @@ extension Conversation {
     func handleIncomingEvent(_ event: IncomingEvent) async {
         switch event {
         case let .userTranscript(e):
-            appendUserTranscript(e.transcript)
+            insertUserTranscript(content: e.transcript, eventId: e.eventId)
             agentStateManager?.processSignal(.userTranscript)
             options.onUserTranscript?(e.transcript, e.eventId)
 
@@ -16,7 +16,7 @@ extension Conversation {
             agentStateManager?.processSignal(.agentResponse)
 
         case let .agentResponse(e):
-            appendAgentMessage(e.response)
+            upsertAgentMessage(content: e.response, eventId: e.eventId)
             lastAgentEventId = e.eventId
             agentStateManager?.processSignal(.agentResponse)
             options.onAgentResponse?(e.response, e.eventId)
@@ -25,7 +25,7 @@ extension Conversation {
             }
 
         case let .agentResponseCorrection(correction):
-            // Handle agent response corrections
+            upsertAgentMessage(content: correction.correctedAgentResponse, eventId: correction.eventId)
             options.onAgentResponseCorrection?(
                 correction.originalAgentResponse,
                 correction.correctedAgentResponse,
@@ -39,7 +39,8 @@ extension Conversation {
             )
 
         case let .agentChatResponsePart(e):
-            handleAgentChatResponsePart(e)
+            let existing = messages.last(where: { $0.role == .agent && $0.eventId == e.eventId })?.content ?? ""
+            upsertAgentMessage(content: existing + e.text, eventId: e.eventId)
 
         case let .audio(audioEvent):
             latestAudioEvent = audioEvent
@@ -111,52 +112,35 @@ extension Conversation {
         }
     }
 
-    func handleAgentChatResponsePart(_ event: AgentChatResponsePartEvent) {
-        switch event.type {
-        case .start:
-            let newMessage = Message(
-                id: UUID().uuidString,
+    /// Inserts the user transcript before the agent message with the same `eventId`
+    /// if one exists, since the agent's response may be received before the transcript.
+    private func insertUserTranscript(content: String, eventId: Int) {
+        let message = Message(
+            id: UUID().uuidString,
+            role: .user,
+            content: content,
+            timestamp: Date(),
+            eventId: eventId
+        )
+        if let agentIdx = messages.firstIndex(where: { $0.role == .agent && $0.eventId == eventId }) {
+            messages.insert(message, at: agentIdx)
+        } else {
+            messages.append(message)
+        }
+    }
+
+    private func upsertAgentMessage(content: String, eventId: Int) {
+        if let idx = messages.lastIndex(where: { $0.role == .agent && $0.eventId == eventId }) {
+            let existing = messages[idx]
+            messages[idx] = Message(
+                id: existing.id,
                 role: .agent,
-                content: event.text,
-                timestamp: Date()
+                content: content,
+                timestamp: existing.timestamp,
+                eventId: eventId
             )
-            currentStreamingMessage = newMessage
-            messages.append(newMessage)
-
-        case .delta:
-            guard let streamingMessage = currentStreamingMessage else {
-                handleAgentChatResponsePart(
-                    AgentChatResponsePartEvent(text: event.text, type: .start)
-                )
-                return
-            }
-
-            messages.removeAll { $0.id == streamingMessage.id }
-            let updatedContent = streamingMessage.content + event.text
-            let updatedMessage = Message(
-                id: streamingMessage.id,
-                role: .agent,
-                content: updatedContent,
-                timestamp: streamingMessage.timestamp
-            )
-            currentStreamingMessage = updatedMessage
-            messages.append(updatedMessage)
-
-        case .stop:
-            if let streamingMessage = currentStreamingMessage {
-                if !event.text.isEmpty {
-                    messages.removeAll { $0.id == streamingMessage.id }
-                    let finalContent = streamingMessage.content + event.text
-                    let finalMessage = Message(
-                        id: streamingMessage.id,
-                        role: .agent,
-                        content: finalContent,
-                        timestamp: streamingMessage.timestamp
-                    )
-                    messages.append(finalMessage)
-                }
-            }
-            currentStreamingMessage = nil
+        } else {
+            appendMessage(role: .agent, content: content, eventId: eventId)
         }
     }
 }

--- a/Sources/ElevenLabs/Internal/Protocol/schemas/agent.asyncapi.yaml
+++ b/Sources/ElevenLabs/Internal/Protocol/schemas/agent.asyncapi.yaml
@@ -845,13 +845,16 @@ components:
 
     AgentChatResponsePartData:
       type: object
-      required: [text, type]
+      required: [text, type, event_id]
       properties:
         text:
           type: string
           description: Text chunk (empty for start/stop events)
         type:
           $ref: "#/components/schemas/AgentChatResponsePartType"
+        event_id:
+          type: integer
+          description: Identifier shared by all chunks of a single response and by the corresponding agent_response
 
     InterruptionData:
       type: object

--- a/Sources/ElevenLabs/Internal/Utilities/EventParser.swift
+++ b/Sources/ElevenLabs/Internal/Utilities/EventParser.swift
@@ -257,11 +257,14 @@ enum EventParser {
 
         case "agent_chat_response_part":
             if let event = json["text_response_part"] as? [String: Any],
-               let text = event["text"] as? String
+               let text = event["text"] as? String,
+               let eventId = event["event_id"] as? Int
             {
                 let partTypeStr = event["type"] as? String ?? "delta"
                 let partType = AgentChatResponsePartType(rawValue: partTypeStr) ?? .delta
-                return .agentChatResponsePart(AgentChatResponsePartEvent(text: text, type: partType))
+                return .agentChatResponsePart(
+                    AgentChatResponsePartEvent(text: text, type: partType, eventId: eventId)
+                )
             }
 
         case "error":

--- a/Sources/ElevenLabs/Public/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Conversation.swift
@@ -49,8 +49,6 @@ public final class Conversation: ObservableObject {
     @Published public internal(set) var audioDevices: [AudioDevice] = []
     @Published public internal(set) var selectedAudioDeviceID: String = ""
 
-    /// Track the current streaming message for chat response parts
-    var currentStreamingMessage: Message?
     var lastAgentEventId: Int?
     var lastFeedbackSubmittedEventId: Int?
 
@@ -280,7 +278,7 @@ public final class Conversation: ObservableObject {
             // No connection manager yet, just reset state
             if state == .connecting {
                 state = .idle
-                cleanupPreviousConversation()
+                tearDownActiveSession()
             }
             return
         }
@@ -289,7 +287,7 @@ public final class Conversation: ObservableObject {
         // Disconnect synchronously to ensure clean state
         await connectionManager.disconnect()
 
-        cleanupPreviousConversation()
+        tearDownActiveSession()
 
         // Call user's onDisconnect callback if provided
         options.onDisconnect?(disconnectReason)
@@ -303,7 +301,7 @@ public final class Conversation: ObservableObject {
         }
         let event = OutgoingEvent.userMessage(UserMessageEvent(text: text))
         try await publish(event)
-        appendLocalMessage(text)
+        appendMessage(role: .user, content: text)
     }
 
     /// Toggle / set microphone
@@ -517,29 +515,35 @@ public final class Conversation: ObservableObject {
     }
 
     /// Clean up state from any previous conversation to ensure a fresh start.
-    /// This method ensures that each new conversation starts with a clean slate,
-    /// preventing any state leakage between conversations when using new Room objects.
+    /// Called when starting a new session; wipes both operational and display state.
     private func cleanupPreviousConversation() {
-        cleanupTransientResources()
+        tearDownActiveSession()
 
-        // Clear conversation state
         messages.removeAll()
-        pendingToolCalls.removeAll()
         mcpToolCalls.removeAll()
         mcpConnectionStatus = nil
         conversationMetadata = nil
-        currentStreamingMessage = nil
 
         startupState = .idle
         startupMetrics = nil
+
+        logger.debug("Previous conversation state cleaned up for fresh Room", context: activeContext)
+    }
+
+    /// Tear down operational state when an active session ends.
+    /// Preserves user-visible display state (messages, MCP activity, conversation
+    /// metadata, startup metrics) so the transcript remains visible until a new
+    /// conversation is started.
+    private func tearDownActiveSession() {
+        cleanupTransientResources()
+
+        pendingToolCalls.removeAll()
 
         lastAgentEventId = nil
         lastFeedbackSubmittedEventId = nil
         options.onCanSendFeedbackChange?(false)
         latestAudioEvent = nil
         latestAudioAlignment = nil
-
-        logger.debug("Previous conversation state cleaned up for fresh Room", context: activeContext)
     }
 
     private func cleanupTransientResources() {
@@ -593,36 +597,14 @@ public final class Conversation: ObservableObject {
 
     // MARK: - Message Helpers
 
-    func appendLocalMessage(_ text: String) {
+    func appendMessage(role: Message.Role, content: String, eventId: Int? = nil) {
         messages.append(
             Message(
                 id: UUID().uuidString,
-                role: .user,
-                content: text,
-                timestamp: Date()
-            )
-        )
-    }
-
-    func appendAgentMessage(_ text: String) {
-        messages.append(
-            Message(
-                id: UUID().uuidString,
-                role: .agent,
-                content: text,
-                timestamp: Date()
-            )
-        )
-    }
-
-    func appendUserTranscript(_ text: String) {
-        // If you want partial transcript merging, do it here
-        messages.append(
-            Message(
-                id: UUID().uuidString,
-                role: .user,
-                content: text,
-                timestamp: Date()
+                role: role,
+                content: content,
+                timestamp: Date(),
+                eventId: eventId
             )
         )
     }

--- a/Sources/ElevenLabs/Public/Conversation/Models/Message.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Models/Message.swift
@@ -5,6 +5,8 @@ public struct Message: Identifiable, Sendable {
     public let role: Role
     public let content: String
     public let timestamp: Date
+    /// Server-assigned event id used for per-message operations like `sendFeedback`; `nil` for locally appended messages.
+    public let eventId: Int?
 
     public enum Role: Sendable {
         case user

--- a/Sources/ElevenLabs/Public/ElevenLabs/Events/IncomingEvents.swift
+++ b/Sources/ElevenLabs/Public/ElevenLabs/Events/IncomingEvents.swift
@@ -65,6 +65,7 @@ public struct AgentResponseMetadataEvent: Sendable {
 public struct AgentChatResponsePartEvent: Sendable {
     public let text: String
     public let type: AgentChatResponsePartType
+    public let eventId: Int
 }
 
 /// Audio alignment data showing character-level timing information

--- a/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
+++ b/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
@@ -63,7 +63,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
 
     func testAgentStreamingMessages() async {
         // 1. Start streaming
-        let startEvent = AgentChatResponsePartEvent(text: "Hello", type: .start)
+        let startEvent = AgentChatResponsePartEvent(text: "Hello", type: .start, eventId: 1)
         await conversation._testing_handleIncomingEvent(.agentChatResponsePart(startEvent))
 
         XCTAssertEqual(conversation.messages.count, 1)
@@ -71,14 +71,14 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
         XCTAssertEqual(conversation.messages.first?.role, .agent)
 
         // 2. Delta update
-        let deltaEvent = AgentChatResponsePartEvent(text: " world", type: .delta)
+        let deltaEvent = AgentChatResponsePartEvent(text: " world", type: .delta, eventId: 1)
         await conversation._testing_handleIncomingEvent(.agentChatResponsePart(deltaEvent))
 
         XCTAssertEqual(conversation.messages.count, 1, "Should still have only 1 message, just updated")
         XCTAssertEqual(conversation.messages.first?.content, "Hello world")
 
         // 3. Stop streaming
-        let stopEvent = AgentChatResponsePartEvent(text: "!", type: .stop)
+        let stopEvent = AgentChatResponsePartEvent(text: "!", type: .stop, eventId: 1)
         await conversation._testing_handleIncomingEvent(.agentChatResponsePart(stopEvent))
 
         XCTAssertEqual(conversation.messages.count, 1)

--- a/Tests/ElevenLabsTests/Unit/ConversationEventHandlerTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationEventHandlerTests.swift
@@ -82,7 +82,118 @@ final class ConversationEventHandlerTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 1.0)
         XCTAssertEqual(conversation.messages.last?.content, "I am an AI")
         XCTAssertEqual(conversation.messages.last?.role, .agent)
+        XCTAssertEqual(conversation.messages.last?.eventId, 456)
         XCTAssertEqual(conversation.lastAgentEventId, 456)
+    }
+
+    func testAgentResponseFinalizesStreamedMessageInsteadOfDuplicating() async {
+        await conversation.handleIncomingEvent(.agentChatResponsePart(
+            AgentChatResponsePartEvent(text: "Hello", type: .start, eventId: 42)
+        ))
+        await conversation.handleIncomingEvent(.agentChatResponsePart(
+            AgentChatResponsePartEvent(text: " World", type: .stop, eventId: 42)
+        ))
+        XCTAssertEqual(conversation.messages.count, 1)
+        XCTAssertEqual(
+            conversation.messages.last?.eventId,
+            42,
+            "Streamed message should already carry the turn's eventId"
+        )
+
+        await conversation.handleIncomingEvent(.agentResponse(
+            AgentResponseEvent(response: "Hello World", eventId: 42)
+        ))
+
+        XCTAssertEqual(
+            conversation.messages.count,
+            1,
+            "agent_response must not duplicate the streamed message"
+        )
+        XCTAssertEqual(conversation.messages.last?.content, "Hello World")
+        XCTAssertEqual(conversation.messages.last?.eventId, 42)
+    }
+
+    func testAgentResponseAppendsWhenNoStreamedMessagePending() async {
+        await conversation.handleIncomingEvent(.agentResponse(
+            AgentResponseEvent(response: "First", eventId: 1)
+        ))
+        await conversation.handleIncomingEvent(.agentResponse(
+            AgentResponseEvent(response: "Second", eventId: 2)
+        ))
+
+        XCTAssertEqual(conversation.messages.count, 2)
+        XCTAssertEqual(conversation.messages[0].eventId, 1)
+        XCTAssertEqual(conversation.messages[1].eventId, 2)
+    }
+
+    // MARK: - Agent Response Correction Tests
+
+    func testAgentResponseCorrectionUpdatesStoredMessage() async {
+        await conversation.handleIncomingEvent(.agentResponse(
+            AgentResponseEvent(response: "the answr is 41", eventId: 7)
+        ))
+        XCTAssertEqual(conversation.messages.last?.content, "the answr is 41")
+
+        await conversation.handleIncomingEvent(.agentResponseCorrection(
+            AgentResponseCorrectionEvent(
+                originalAgentResponse: "the answr is 41",
+                correctedAgentResponse: "the answer is 42",
+                eventId: 7
+            )
+        ))
+
+        XCTAssertEqual(
+            conversation.messages.count,
+            1,
+            "Correction should update in place, not append"
+        )
+        XCTAssertEqual(conversation.messages.last?.content, "the answer is 42")
+        XCTAssertEqual(conversation.messages.last?.eventId, 7)
+    }
+
+    func testAgentResponseCorrectionWithUnknownEventIdAppends() async {
+        await conversation.handleIncomingEvent(.agentResponse(
+            AgentResponseEvent(response: "kept as-is", eventId: 100)
+        ))
+
+        await conversation.handleIncomingEvent(.agentResponseCorrection(
+            AgentResponseCorrectionEvent(
+                originalAgentResponse: "x",
+                correctedAgentResponse: "y",
+                eventId: 999
+            )
+        ))
+
+        XCTAssertEqual(conversation.messages.count, 2)
+        XCTAssertEqual(conversation.messages[0].content, "kept as-is")
+        XCTAssertEqual(conversation.messages[0].eventId, 100)
+        XCTAssertEqual(conversation.messages[1].content, "y")
+        XCTAssertEqual(conversation.messages[1].eventId, 999)
+    }
+
+    // MARK: - User Transcript eventId
+
+    func testUserTranscriptCarriesEventId() async {
+        await conversation.handleIncomingEvent(.userTranscript(
+            UserTranscriptEvent(transcript: "hi", eventId: 11)
+        ))
+        XCTAssertEqual(conversation.messages.last?.eventId, 11)
+        XCTAssertEqual(conversation.messages.last?.role, .user)
+    }
+
+    func testUserTranscriptInsertedBeforeAgentMessageWithSameEventId() async {
+        await conversation.handleIncomingEvent(.agentResponse(
+            AgentResponseEvent(response: "agent reply", eventId: 5)
+        ))
+        await conversation.handleIncomingEvent(.userTranscript(
+            UserTranscriptEvent(transcript: "user said this", eventId: 5)
+        ))
+
+        XCTAssertEqual(conversation.messages.count, 2)
+        XCTAssertEqual(conversation.messages[0].role, .user)
+        XCTAssertEqual(conversation.messages[0].content, "user said this")
+        XCTAssertEqual(conversation.messages[1].role, .agent)
+        XCTAssertEqual(conversation.messages[1].content, "agent reply")
     }
 
     // MARK: - Interruption Tests
@@ -112,30 +223,25 @@ final class ConversationEventHandlerTests: XCTestCase {
 
     func testHandleAgentChatResponseStream() async {
         // 1. Start
-        let startEvent = IncomingEvent.agentChatResponsePart(AgentChatResponsePartEvent(
-            text: "Hello",
-            type: .start
+        await conversation.handleIncomingEvent(.agentChatResponsePart(
+            AgentChatResponsePartEvent(text: "Hello", type: .start, eventId: 13)
         ))
-        await conversation.handleIncomingEvent(startEvent)
-        XCTAssertEqual(conversation.currentStreamingMessage?.content, "Hello")
         XCTAssertEqual(conversation.messages.count, 1)
+        XCTAssertEqual(conversation.messages.last?.content, "Hello")
+        XCTAssertEqual(conversation.messages.last?.eventId, 13)
 
         // 2. Delta
-        let deltaEvent = IncomingEvent.agentChatResponsePart(AgentChatResponsePartEvent(
-            text: " World",
-            type: .delta
+        await conversation.handleIncomingEvent(.agentChatResponsePart(
+            AgentChatResponsePartEvent(text: " World", type: .delta, eventId: 13)
         ))
-        await conversation.handleIncomingEvent(deltaEvent)
-        XCTAssertEqual(conversation.currentStreamingMessage?.content, "Hello World")
         XCTAssertEqual(conversation.messages.count, 1, "Should update existing message")
+        XCTAssertEqual(conversation.messages.last?.content, "Hello World")
 
         // 3. Stop
-        let stopEvent = IncomingEvent.agentChatResponsePart(AgentChatResponsePartEvent(
-            text: "!",
-            type: .stop
+        await conversation.handleIncomingEvent(.agentChatResponsePart(
+            AgentChatResponsePartEvent(text: "!", type: .stop, eventId: 13)
         ))
-        await conversation.handleIncomingEvent(stopEvent)
-        XCTAssertNil(conversation.currentStreamingMessage)
         XCTAssertEqual(conversation.messages.last?.content, "Hello World!")
+        XCTAssertEqual(conversation.messages.last?.eventId, 13)
     }
 }

--- a/Tests/ElevenLabsTests/Unit/EventParserTests.swift
+++ b/Tests/ElevenLabsTests/Unit/EventParserTests.swift
@@ -198,7 +198,8 @@ final class EventParserTests: XCTestCase {
             "type": "agent_chat_response_part",
             "text_response_part": {
                 "text": "",
-                "type": "start"
+                "type": "start",
+                "event_id": 13
             }
         }
         """.data(using: .utf8)!
@@ -212,6 +213,7 @@ final class EventParserTests: XCTestCase {
 
         XCTAssertEqual(part.text, "")
         XCTAssertEqual(part.type, .start)
+        XCTAssertEqual(part.eventId, 13)
     }
 
     func testParseAgentChatResponsePartDelta() throws {
@@ -220,7 +222,8 @@ final class EventParserTests: XCTestCase {
             "type": "agent_chat_response_part",
             "text_response_part": {
                 "text": "Hello",
-                "type": "delta"
+                "type": "delta",
+                "event_id": 13
             }
         }
         """.data(using: .utf8)!
@@ -234,6 +237,7 @@ final class EventParserTests: XCTestCase {
 
         XCTAssertEqual(part.text, "Hello")
         XCTAssertEqual(part.type, .delta)
+        XCTAssertEqual(part.eventId, 13)
     }
 
     func testParseAgentChatResponsePartStop() throws {
@@ -242,7 +246,8 @@ final class EventParserTests: XCTestCase {
             "type": "agent_chat_response_part",
             "text_response_part": {
                 "text": "",
-                "type": "stop"
+                "type": "stop",
+                "event_id": 13
             }
         }
         """.data(using: .utf8)!
@@ -256,6 +261,7 @@ final class EventParserTests: XCTestCase {
 
         XCTAssertEqual(part.text, "")
         XCTAssertEqual(part.type, .stop)
+        XCTAssertEqual(part.eventId, 13)
     }
 
     func testParseAgentChatResponsePartDefaultsToDelta() throws {
@@ -263,7 +269,8 @@ final class EventParserTests: XCTestCase {
         {
             "type": "agent_chat_response_part",
             "text_response_part": {
-                "text": "Test"
+                "text": "Test",
+                "event_id": 13
             }
         }
         """.data(using: .utf8)!
@@ -277,6 +284,7 @@ final class EventParserTests: XCTestCase {
 
         XCTAssertEqual(part.text, "Test")
         XCTAssertEqual(part.type, .delta)
+        XCTAssertEqual(part.eventId, 13)
     }
 
     func testParseAgentResponseMetadataEvent() throws {


### PR DESCRIPTION
The SDK exposes [messages](https://elevenlabs.io/docs/eleven-agents/libraries/swift#message-handling) but there were several issues that this PR addresses:

- `agentResponseCorrection` used to be ignored, we use it to update messages now
- `agent_response` and `agentChatResponsePart` used to cause duplicated messages - we reconcile them now using event_id
- `messages` survives disconnection now (previously we wiped it as soon as the conversation is over, which is a weird UX). We still wipe it before starting a new conversation. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core conversation event-to-message reconciliation and session teardown behavior, which can affect message ordering/deduping and UI-visible state across disconnects. Also updates protocol parsing for `agent_chat_response_part` to require `event_id`, which must match server payloads.
> 
> **Overview**
> **Fixes message lifecycle and ordering in `Conversation.messages`.** Agent messages are now *upserted by `eventId`* so `agent_response`, streamed `agent_chat_response_part`, and `agent_response_correction` update a single message instead of creating duplicates, and streamed parts require/propagate `event_id` from the protocol/parser.
> 
> **Improves UX on disconnect.** Ending a conversation now tears down operational state while preserving the message transcript (and other display state) until the next `startConversation`, which still performs a full reset.
> 
> **Simplifies internal dependency and error plumbing.** Removes `errorHandler` from connection managers/dependency provider, makes dependencies eagerly initialized properties, and updates startup/connection code and tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d33f490a2677542480052e891e14a0d536cf829e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->