### PR TITLE
chore: bump version to 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add the package via Swift Package Manager:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/elevenlabs/elevenlabs-swift-sdk.git", from: "3.1.4")
+    .package(url: "https://github.com/elevenlabs/elevenlabs-swift-sdk.git", from: "3.2.0")
 ]
 ```
 

--- a/Sources/ElevenLabs/Internal/Version.swift
+++ b/Sources/ElevenLabs/Internal/Version.swift
@@ -3,5 +3,5 @@
 import Foundation
 
 enum SDKVersion {
-    static let version = "3.1.5"
+    static let version = "3.2.0"
 }

--- a/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
+++ b/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
@@ -20,7 +20,7 @@ import LiveKit
 public enum ElevenLabs {
     // MARK: - Version
 
-    public static let version = "3.1.4"
+    public static let version = "3.2.0"
 
     // MARK: - Configuration
 

--- a/Tests/ElevenLabsTests/Unit/ElevenLabsSDKTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ElevenLabsSDKTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class ElevenLabsSDKTests: XCTestCase {
     func testSDKVersionExists() {
-        XCTAssertEqual(ElevenLabs.version, "3.1.4")
+        XCTAssertEqual(ElevenLabs.version, "3.2.0")
         XCTAssertFalse(ElevenLabs.version.isEmpty)
     }
 


### PR DESCRIPTION
## Summary
- Bumps SDK version to 3.2.0 across `Version.swift`, `ElevenLabs.swift`, the version test, and the README install snippet.

Changes:

- https://github.com/elevenlabs/elevenlabs-swift-sdk/pull/179 
  - fixes https://github.com/elevenlabs/elevenlabs-swift-sdk/issues/94
- https://github.com/elevenlabs/elevenlabs-swift-sdk/pull/180

## Test plan
- [x] `swift build` passes
- [x] `swift test` passes (119 tests)
- [x] `swiftformat . --strict` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates version strings in the public API, internal version file, README install snippet, and the version assertion test.
> 
> **Overview**
> Bumps the SDK version to `3.2.0` across the public `ElevenLabs.version`, internal `SDKVersion.version`, the README SwiftPM install snippet, and the unit test that asserts the version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d177963354c1b84d9d9045a34651a6731857180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->