### PR TITLE
Enable singlePeerConnection

### DIFF
--- a/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
@@ -153,7 +153,7 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
         )
         self.eventDelegate = eventDelegate
 
-        let room = Room()
+        let room = Room(roomOptions: RoomOptions(singlePeerConnection: true))
         self.room = room
         room.delegates.add(delegate: eventDelegate)
         room.delegates.add(delegate: readinessDelegate)


### PR DESCRIPTION
Enable singlePeerConnection in Livekit's RoomOptions. 
Livekit server was recently upgraded to support singlePeerConnection and it's expected to make connection initiation much faster.


Tested manually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core WebRTC connection topology; behavior depends on server support and could affect connect reliability if mismatched, though scope is a single option flag.
> 
> **Overview**
> Enables LiveKit’s **single peer connection** mode when creating the WebRTC room in `WebRTCConnectionManager.connect`, by passing `RoomOptions(singlePeerConnection: true)` instead of the default `Room()` initializer.
> 
> This aligns the iOS client with upgraded LiveKit server support and is intended to **speed up connection setup**; no other connection, delegate, or readiness logic is changed in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc00942cffdd976be5f72c3f096cc905054983a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->