### PR TITLE
Add Singapore data residency

### DIFF
--- a/Sources/ElevenLabs/Internal/Protocol/schemas/agent.asyncapi.yaml
+++ b/Sources/ElevenLabs/Internal/Protocol/schemas/agent.asyncapi.yaml
@@ -29,6 +29,10 @@ servers:
     url: wss://api.in.residency.elevenlabs.io
     protocol: ws
     description: India residency WebSocket server for data locality
+  sg-residency:
+    url: wss://api.sg.residency.elevenlabs.io
+    protocol: ws
+    description: Singapore residency WebSocket server for data locality
   webrtc:
     url: wss://livekit.rtc.elevenlabs.io
     protocol: ws


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Schema-only addition with no runtime or auth logic changes in this diff.
> 
> **Overview**
> Adds **Singapore data residency** to the Agents WebSocket contract in `agent.asyncapi.yaml`, alongside existing EU and India residency servers.
> 
> Clients can target `wss://api.sg.residency.elevenlabs.io` via the new `sg-residency` server entry (same `ws` protocol and data-locality framing as `in-residency`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68d5c5eabb11a838b70bea57141b4e9991e21c6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->