### PR TITLE
chore: bump version to 3.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add the package via Swift Package Manager:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/elevenlabs/elevenlabs-swift-sdk.git", from: "3.2.0")
+    .package(url: "https://github.com/elevenlabs/elevenlabs-swift-sdk.git", from: "3.2.1")
 ]
 ```
 

--- a/Sources/ElevenLabs/Internal/Version.swift
+++ b/Sources/ElevenLabs/Internal/Version.swift
@@ -3,5 +3,5 @@
 import Foundation
 
 enum SDKVersion {
-    static let version = "3.2.0"
+    static let version = "3.2.1"
 }

--- a/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
+++ b/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
@@ -20,7 +20,7 @@ import LiveKit
 public enum ElevenLabs {
     // MARK: - Version
 
-    public static let version = "3.2.0"
+    public static let version = "3.2.1"
 
     // MARK: - Configuration
 

--- a/Tests/ElevenLabsTests/Unit/ElevenLabsSDKTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ElevenLabsSDKTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class ElevenLabsSDKTests: XCTestCase {
     func testSDKVersionExists() {
-        XCTAssertEqual(ElevenLabs.version, "3.2.0")
+        XCTAssertEqual(ElevenLabs.version, "3.2.1")
         XCTAssertFalse(ElevenLabs.version.isEmpty)
     }
 


### PR DESCRIPTION
Bumps the SDK version from 3.2.0 to 3.2.1.

Includes the two changes since v3.2.0:
- Enable singlePeerConnection (#185)
- Add Singapore data residency (#186)

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` — 119 tests pass
- [x] `swiftformat . --strict` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version string updates only; no functional code changes in this PR.
> 
> **Overview**
> **Bumps the ElevenLabs Swift SDK release from `3.2.0` to `3.2.1`.**
> 
> The public `ElevenLabs.version`, internal `SDKVersion`, README Swift Package Manager minimum version, and the version unit test are all aligned to **3.2.1**. No runtime or API behavior changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e5723a2a3dc39577a7f0d01944b1b75ade09c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->