### PR TITLE
[fix] implement correct room delegate method

### DIFF
--- a/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
@@ -214,7 +214,7 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
 
 /// `RoomDelegate` that forwards data, remote speaking, and remote-disconnect events
 /// (agent leaving or room disconnect) to manager-supplied closures.
-private final class LiveKitRoomEventDelegate: RoomDelegate {
+final class LiveKitRoomEventDelegate: RoomDelegate {
     private let onData: @Sendable (Data) -> Void
     private let onRemoteSpeaking: @Sendable (Bool) -> Void
     private let onRemoteDisconnect: @Sendable () async -> Void
@@ -236,9 +236,9 @@ private final class LiveKitRoomEventDelegate: RoomDelegate {
         onData(data)
     }
 
-    nonisolated func room(_: Room, participant: Participant, didUpdateIsSpeaking isSpeaking: Bool) {
-        guard participant is RemoteParticipant else { return }
-        onRemoteSpeaking(isSpeaking)
+    nonisolated func room(_: Room, didUpdateSpeakingParticipants participants: [Participant]) {
+        // The agent is a remote participant, so any active remote speaker means it's speaking.
+        onRemoteSpeaking(participants.contains { $0 is RemoteParticipant })
     }
 
     nonisolated func room(_ room: Room, participantDidDisconnect participant: RemoteParticipant) {

--- a/Tests/ElevenLabsTests/Unit/LiveKitRoomEventDelegateTests.swift
+++ b/Tests/ElevenLabsTests/Unit/LiveKitRoomEventDelegateTests.swift
@@ -1,0 +1,59 @@
+@testable import ElevenLabs
+import LiveKit
+import XCTest
+
+/// Verifies delegate callbacks implement correct `RoomDelegate` methods
+final class LiveKitRoomEventDelegateTests: XCTestCase {
+    private func makeDelegate(
+        onData: @escaping @Sendable (Data) -> Void = { _ in },
+        onRemoteSpeaking: @escaping @Sendable (Bool) -> Void = { _ in },
+        onRemoteDisconnect: @escaping @Sendable () async -> Void = {}
+    ) -> RoomDelegate {
+        LiveKitRoomEventDelegate(
+            onData: onData,
+            onRemoteSpeaking: onRemoteSpeaking,
+            onRemoteDisconnect: onRemoteDisconnect
+        )
+    }
+
+    func testForwardsReceivedData() async {
+        let received = ValueRecorder<Data>()
+        let delegate = makeDelegate(onData: { value in Task { await received.append(value) } })
+        let payload = Data([0x01, 0x02, 0x03])
+
+        delegate.room?(Room(), participant: nil, didReceiveData: payload, forTopic: "topic", encryptionType: .none)
+
+        let values = await received.values(waitingFor: 1)
+        XCTAssertEqual(values, [payload])
+    }
+
+    func testForwardsSpeaking() async {
+        let speaking = ValueRecorder<Bool>()
+        let delegate = makeDelegate(onRemoteSpeaking: { value in Task { await speaking.append(value) } })
+
+        delegate.room?(Room(), didUpdateSpeakingParticipants: [])
+
+        let values = await speaking.values(waitingFor: 1)
+        XCTAssertEqual(values, [false], "No remote speakers must forward not-speaking.")
+    }
+
+    func testForwardsDisconnectOnConnectionLoss() async {
+        let disconnects = ValueRecorder<Bool>()
+        let delegate = makeDelegate(onRemoteDisconnect: { await disconnects.append(true) })
+
+        delegate.room?(Room(), didUpdateConnectionState: .disconnected, from: .connected)
+
+        let values = await disconnects.values(waitingFor: 1)
+        XCTAssertEqual(values, [true])
+    }
+
+    func testIgnoresNonDisconnectedConnectionState() async {
+        let disconnects = ValueRecorder<Bool>()
+        let delegate = makeDelegate(onRemoteDisconnect: { await disconnects.append(true) })
+
+        delegate.room?(Room(), didUpdateConnectionState: .connected, from: .connecting)
+
+        let values = await disconnects.values(waitingFor: 1, timeout: 0.2)
+        XCTAssertTrue(values.isEmpty, "Only a disconnected state should signal disconnect.")
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/elevenlabs/elevenlabs-swift-sdk/issues/188

### Problem
LiveKitRoomEventDelegate was implementing `nonisolated func room(_: Room, participant: Participant, didUpdateIsSpeaking isSpeaking: Bool)` method to catch speaking updates, but the method doesn't really exist in `RoomDelegate` protocol, so it was never called.

### Fix 
Make it implement the correct method `nonisolated func room(_: Room, didUpdateSpeakingParticipants participants: [Participant])`

### Why it was working before
In older versions there were 2 delegates: RoomDelegate (broken) and ParticipantDelegate (working), and the working one got lost in a recent refactoring as a duplicate.

### Testing
* Added tests to verify that the methods that we implement on `LiveKitRoomEventDelegate` actually exists in `RoomDelegate`.
* Manual testing



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live conversation speaking/disconnect signaling on the WebRTC path; behavior shifts from per-participant updates to list-based remote-speaker detection.
> 
> **Overview**
> **Restores remote agent speaking detection** for WebRTC conversations by implementing LiveKit’s real `room(_:didUpdateSpeakingParticipants:)` callback instead of a `didUpdateIsSpeaking` handler that was never part of `RoomDelegate`, so `onRemoteSpeakingChanged` / conversation UI could stay stuck.
> 
> `LiveKitRoomEventDelegate` now reports **speaking** when the active speakers list includes any `RemoteParticipant`, and **not speaking** when it does not (e.g. an empty list). The delegate type is no longer `private` so tests can exercise it.
> 
> Adds **`LiveKitRoomEventDelegateTests`** to assert data forwarding, speaking updates, and disconnect signaling on connection state changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac859209f953828d6bdb04e5fef7b577a62c809. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->