### PR TITLE
chore: bump version to 3.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add the package via Swift Package Manager:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/elevenlabs/elevenlabs-swift-sdk.git", from: "3.2.1")
+    .package(url: "https://github.com/elevenlabs/elevenlabs-swift-sdk.git", from: "3.2.2")
 ]
 ```
 

--- a/Sources/ElevenLabs/Internal/Version.swift
+++ b/Sources/ElevenLabs/Internal/Version.swift
@@ -3,5 +3,5 @@
 import Foundation
 
 enum SDKVersion {
-    static let version = "3.2.1"
+    static let version = "3.2.2"
 }

--- a/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
+++ b/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
@@ -20,7 +20,7 @@ import LiveKit
 public enum ElevenLabs {
     // MARK: - Version
 
-    public static let version = "3.2.1"
+    public static let version = "3.2.2"
 
     // MARK: - Configuration
 

--- a/Tests/ElevenLabsTests/Unit/ElevenLabsSDKTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ElevenLabsSDKTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class ElevenLabsSDKTests: XCTestCase {
     func testSDKVersionExists() {
-        XCTAssertEqual(ElevenLabs.version, "3.2.1")
+        XCTAssertEqual(ElevenLabs.version, "3.2.2")
         XCTAssertFalse(ElevenLabs.version.isEmpty)
     }
 


### PR DESCRIPTION
Bumps the SDK version to 3.2.2.

Updates the version string in all 4 locations:
- `Sources/ElevenLabs/Internal/Version.swift`
- `Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift`
- `Tests/ElevenLabsTests/Unit/ElevenLabsSDKTests.swift`
- `README.md`

`swift build` and `swift test` (123 tests) pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only version alignment with no runtime, security, or behavioral changes.
> 
> **Overview**
> Bumps the ElevenLabs Swift SDK release from **3.2.1** to **3.2.2** with no functional or API changes.
> 
> The version string is updated in the internal `SDKVersion` helper, the public `ElevenLabs.version` constant, the unit test that asserts the SDK version, and the README SwiftPM `from:` dependency example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8584426afb56eb7fa048660fdd1186cb494494f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->