### PR TITLE
fix(networking): URL hardening and quieter unknown events

### DIFF
--- a/Sources/ElevenLabs/Internal/Conversation/ConnectionManaging.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/ConnectionManaging.swift
@@ -41,6 +41,9 @@ extension ConnectionManaging {
             if let event = try EventParser.parseIncomingEvent(from: data) {
                 onEventReceived?(event)
             }
+        } catch let EventParseError.unknownEventType(type) {
+            // Unrecognized event types are expected (newer server) — not errors.
+            logger.debug("Ignoring unknown incoming event type", context: ["type": type])
         } catch {
             logger.error("Failed to parse incoming event", context: ["error": "\(error)"])
             logger.debug("Incoming raw data bytes", context: ["bytes": "\(data.count)"])

--- a/Sources/ElevenLabs/Internal/Networking/WebSocketConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebSocketConnectionManager.swift
@@ -122,11 +122,12 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
     static func url(for auth: ElevenLabsConfiguration) throws -> URL {
         switch auth.authSource {
         case let .publicAgentId(agentId):
-            var components = URLComponents(string: ConnectionConstants.textConversationUrl)!
-            components.queryItems = [
-                URLQueryItem(name: "agent_id", value: agentId)
-            ]
-            return components.url!
+            var components = URLComponents(string: ConnectionConstants.textConversationUrl)
+            components?.queryItems = [URLQueryItem(name: "agent_id", value: agentId)]
+            guard let url = components?.url else {
+                throw ConversationError.authenticationFailed("Invalid conversation URL")
+            }
+            return url
 
         case let .signedWebSocketURL(urlString, _):
             guard let url = URL(string: urlString) else {


### PR DESCRIPTION
- ConnectionManaging: log unknown incoming event types at .debug instead of .error, so new server events don't flood consumer logs.
- WebSocketConnectionManager: replace two force-unwraps in url(for:) with a guarded throw so a malformed base URL surfaces as a recoverable error instead of a crash.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive networking and logging changes with no auth or data-model changes; malformed URLs become explicit errors instead of crashes.
> 
> **Overview**
> **Incoming WebSocket events** from newer servers that the SDK does not recognize are now handled explicitly: `EventParseError.unknownEventType` is caught in `ConnectionManaging.handleIncomingData` and logged at **debug** with the event type, instead of being treated like a parse failure and logged as **error**.
> 
> **Text conversation URL construction** for the public-agent auth path no longer force-unwraps `URLComponents` / `url`. A failed build throws `ConversationError.authenticationFailed("Invalid conversation URL")`, which flows through existing `connect` error handling as a startup failure rather than crashing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5156afd12cde51b9ce9f5ca7c487a7413f2e7e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->