### PR TITLE
optimization(audio): drop realtime-thread allocation in SoftwareMuteProcessor

### DIFF
--- a/Sources/ElevenLabs/Internal/Utilities/SoftwareMuteProcessor.swift
+++ b/Sources/ElevenLabs/Internal/Utilities/SoftwareMuteProcessor.swift
@@ -62,14 +62,11 @@ final class SoftwareMuteProcessor: NSObject, @unchecked Sendable, AudioCustomPro
         let vCount = vDSP_Length(frameCount)
 
         var totalRMS: Float = 0
-        for i in 0 ..< audioBuffer.channels {
+        for i in 0 ..< channelCount {
             let ptr = audioBuffer.rawBuffer(forChannel: i)
-            var normalized = [Float](repeating: 0, count: frameCount)
-            var divisor: Float = 32768.0
-            vDSP_vsdiv(ptr, 1, &divisor, &normalized, 1, vCount)
             var channelRMS: Float = 0
-            vDSP_rmsqv(normalized, 1, &channelRMS, vCount)
-            totalRMS += channelRMS
+            vDSP_rmsqv(ptr, 1, &channelRMS, vCount)
+            totalRMS += channelRMS / 32768.0
         }
         let averageRMS = totalRMS / Float(max(audioBuffer.channels, 1))
         let db = 20 * log10(max(averageRMS, 1e-6))


### PR DESCRIPTION
Avoid unnecessary allocation in RMS calculation.

Before:
1. take an array of raw samples
2. allocate a new array of the same size for normalized samples
3. divide raw samples by 32768 and write the result to the normalized array from step 2
4. compute RMS on the normalized array - result is a single number

After:
1. take an array of raw samples
2. compute RMS on the raw samples - result is a single number
3. divide that number by 32768


(confirmed that there shouldn't be overflow issues)


Testing
* unit tests
* manual test - triggered "speaking while muted" callback
