### PR TITLE
Move callbacks out of ConversationConfig into ConversationCallbacks (breaking)

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -132,7 +132,7 @@ class AudioControlViewModel: ObservableObject {
     func startConversation(agentId: String) async throws {
         conversation = try await ElevenLabs.startConversation(
             agentId: agentId,
-            config: .init(
+            callbacks: .init(
                 onAgentReady: { [weak self] in
                     Task { @MainActor in
                         self?.isAgentReady = true
@@ -468,10 +468,10 @@ struct MCPApprovalView: View {
 
 ## Event Callbacks
 
-For non-reactive integrations, use fine-grained callbacks in `ConversationConfig`.
+For non-reactive integrations, use fine-grained callbacks via `ConversationCallbacks`.
 
 ```swift
-let config = ConversationConfig(
+let callbacks = ConversationCallbacks(
     onAgentResponse: { text, eventId in 
         print("Agent finalized response: \(text)")
     },
@@ -547,7 +547,7 @@ Handle feedback (like/dislike) and contextual updates to the agent.
 // 1) Setup: react to feedback availability
 var canSendFeedback = false
 
-let cfg = ConversationConfig(
+let callbacks = ConversationCallbacks(
     onAgentResponse: { text, eventId in
         print("Agent:", text, "(event:", eventId, ")")
     },
@@ -557,7 +557,7 @@ let cfg = ConversationConfig(
     }
 )
 
-let conversation = try await ElevenLabs.startConversation(agentId: "agent_123", config: cfg)
+let conversation = try await ElevenLabs.startConversation(agentId: "agent_123", callbacks: callbacks)
 
 // 2) Sending feedback from your UI
 func thumbsUp(latestEventId: Int) {
@@ -672,7 +672,7 @@ struct ConversationView: View {
 Monitor the user's voice intensity for custom animations or meters.
 
 ```swift
-let config = ConversationConfig(
+let callbacks = ConversationCallbacks(
     onVadScore: { score in
         // score is a float from 0.0 to 1.0
         // 0.0 = Silence, 1.0 = Loud Speech

--- a/README.md
+++ b/README.md
@@ -231,16 +231,16 @@ ElevenLabs.configure(
 
 ### Fine-Grained Callbacks
 
-Want to handle events without Combine? Use `ConversationConfig`:
+Want to handle events without Combine? Use `ConversationCallbacks`:
 
 ```swift
-let config = ConversationConfig(
+let callbacks = ConversationCallbacks(
     onAgentResponse: { text, _ in print("Agent said: \(text)") },
     onUserTranscript: { text, _ in print("User said: \(text)") },
     onVadScore: { score in print("Voice intensity: \(score)") }
 )
 
-let conversation = try await ElevenLabs.startConversation(agentId: "id", config: config)
+let conversation = try await ElevenLabs.startConversation(agentId: "id", callbacks: callbacks)
 ```
 
 ---

--- a/Sources/ElevenLabs/Internal/Conversation/Conversation+Events.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/Conversation+Events.swift
@@ -10,27 +10,27 @@ extension Conversation {
         case let .userTranscript(e):
             insertUserTranscript(content: e.transcript, eventId: e.eventId)
             agentStateManager?.processSignal(.userTranscript)
-            options.onUserTranscript?(e.transcript, e.eventId)
+            callbacks.onUserTranscript?(e.transcript, e.eventId)
 
         case let .agentResponse(e):
             upsertAgentMessage(content: e.response, eventId: e.eventId)
             lastAgentEventId = e.eventId
             agentStateManager?.processSignal(.agentResponse)
-            options.onAgentResponse?(e.response, e.eventId)
+            callbacks.onAgentResponse?(e.response, e.eventId)
             if lastFeedbackSubmittedEventId.map({ e.eventId > $0 }) ?? true {
-                options.onCanSendFeedbackChange?(true)
+                callbacks.onCanSendFeedbackChange?(true)
             }
 
         case let .agentResponseCorrection(correction):
             upsertAgentMessage(content: correction.correctedAgentResponse, eventId: correction.eventId)
-            options.onAgentResponseCorrection?(
+            callbacks.onAgentResponseCorrection?(
                 correction.originalAgentResponse,
                 correction.correctedAgentResponse,
                 correction.eventId
             )
 
         case let .agentResponseMetadata(metadata):
-            options.onAgentResponseMetadata?(
+            callbacks.onAgentResponseMetadata?(
                 metadata.metadataData,
                 metadata.eventId
             )
@@ -43,19 +43,19 @@ extension Conversation {
             latestAudioEvent = audioEvent
             latestAudioAlignment = audioEvent.alignment
             if let alignment = audioEvent.alignment {
-                options.onAudioAlignment?(alignment)
+                callbacks.onAudioAlignment?(alignment)
             }
 
         case let .interruption(interruptionEvent):
             speakingTimer?.cancel()
             applyStateSignal(.interruption, fallback: .listening)
-            options.onInterruption?(interruptionEvent.eventId)
-            options.onCanSendFeedbackChange?(false)
+            callbacks.onInterruption?(interruptionEvent.eventId)
+            callbacks.onCanSendFeedbackChange?(false)
 
         case let .conversationMetadata(metadata):
             // Store the conversation metadata for public access
             conversationMetadata = metadata
-            options.onConversationMetadata?(metadata)
+            callbacks.onConversationMetadata?(metadata)
 
         case let .ping(p):
             // Respond to ping with pong
@@ -64,12 +64,12 @@ extension Conversation {
 
         case let .clientToolCall(toolCall):
             // Add to pending tool calls for the app to handle
-            options.onUnhandledClientToolCall?(toolCall)
+            callbacks.onUnhandledClientToolCall?(toolCall)
             pendingToolCalls.append(toolCall)
 
         case let .vadScore(vad):
             agentStateManager?.processSignal(.vadScore(vad.vadScore))
-            options.onVadScore?(vad.vadScore)
+            callbacks.onVadScore?(vad.vadScore)
 
         case let .agentToolResponse(toolResponse):
             applyStateSignal(.agentToolResponse, fallback: .listening)
@@ -77,11 +77,11 @@ extension Conversation {
             if toolResponse.toolName == "end_call" {
                 await endConversation()
             }
-            options.onAgentToolResponse?(toolResponse)
+            callbacks.onAgentToolResponse?(toolResponse)
 
         case let .agentToolRequest(toolRequest):
             applyStateSignal(.agentToolRequest, fallback: .thinking)
-            options.onAgentToolRequest?(toolRequest)
+            callbacks.onAgentToolRequest?(toolRequest)
 
         case .tentativeUserTranscript:
             // Tentative user transcript (in-progress transcription)
@@ -101,7 +101,7 @@ extension Conversation {
 
         case let .error(errorEvent):
             logger.error("Received error event from server: code=\(errorEvent.code), message=\(errorEvent.message ?? "none")")
-            options.onError?(.serverError(errorEvent))
+            callbacks.onError?(.serverError(errorEvent))
         }
     }
 

--- a/Sources/ElevenLabs/Internal/Conversation/ConversationAudioManager.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/ConversationAudioManager.swift
@@ -112,21 +112,15 @@ final class ConversationAudioManager {
 
     private func configureSpeechHandler(options: ConversationOptions) {
         let config = options.audioConfiguration
-        let needsSpeechHandler = (config?.onSpeechActivity != nil) || (options.onSpeechActivity != nil)
 
-        if needsSpeechHandler {
+        if config?.onSpeechActivity != nil {
             if !audioSpeechHandlerInstalled {
                 previousSpeechActivityHandler = audioManager.onMutedSpeechActivity
                 audioSpeechHandlerInstalled = true
             }
             audioManager.onMutedSpeechActivity = { _, event in
                 // Handlers are @Sendable, they manage their own synchronization
-                if let handler = config?.onSpeechActivity {
-                    handler(event)
-                }
-                if let handler = options.onSpeechActivity {
-                    handler(event)
-                }
+                config?.onSpeechActivity?(event)
             }
         } else if audioSpeechHandlerInstalled {
             cleanupSpeechHandler()

--- a/Sources/ElevenLabs/Public/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Conversation.swift
@@ -100,10 +100,12 @@ public final class Conversation: ObservableObject {
 
     init(
         dependencyProvider: any ConversationDependencyProvider,
-        options: ConversationOptions = .default
+        options: ConversationOptions = .default,
+        callbacks: ConversationCallbacks = .init()
     ) {
         self.dependencyProvider = dependencyProvider
         self.options = options
+        self.callbacks = callbacks
         logger = dependencyProvider.logger
         setupAudioManager()
     }
@@ -128,7 +130,7 @@ public final class Conversation: ObservableObject {
         let manager = AgentStateManager(configuration: configuration)
         manager.onStateChange = { [weak self] state in
             self?.agentState = state
-            self?.options.onAgentStateChange?(state)
+            self?.callbacks.onAgentStateChange?(state)
         }
         agentStateManager = manager
     }
@@ -168,7 +170,7 @@ public final class Conversation: ObservableObject {
         state = .active(.init(agentId: result.agentId))
         startupMetrics = result.metrics
         updateStartupState(.active(CallInfo(agentId: result.agentId), result.metrics))
-        options.onAgentReady?()
+        callbacks.onAgentReady?()
     }
 
     private func startVoiceConversation(
@@ -273,8 +275,8 @@ public final class Conversation: ObservableObject {
         tearDownActiveSession()
 
         // Call user's onDisconnect callback if provided
-        options.onDisconnect?(disconnectReason)
-        options.onCanSendFeedbackChange?(false)
+        callbacks.onDisconnect?(disconnectReason)
+        callbacks.onCanSendFeedbackChange?(false)
     }
 
     /// Send a text message to the agent.
@@ -351,7 +353,7 @@ public final class Conversation: ObservableObject {
         let event = OutgoingEvent.feedback(FeedbackEvent(score: score, eventId: eventId))
         try await publish(event)
         lastFeedbackSubmittedEventId = eventId
-        options.onCanSendFeedbackChange?(false)
+        callbacks.onCanSendFeedbackChange?(false)
     }
 
     /// Approve or reject an MCP tool call request from the agent.
@@ -408,12 +410,13 @@ public final class Conversation: ObservableObject {
     }
 
     var options: ConversationOptions
+    let callbacks: ConversationCallbacks
 
     var speakingTimer: Task<Void, Never>?
 
     private func updateStartupState(_ newState: ConversationStartupState) {
         startupState = newState
-        options.onStartupStateChange?(newState)
+        callbacks.onStartupStateChange?(newState)
     }
 
     /// Common preparation shared by voice and text-only startup paths.
@@ -439,7 +442,7 @@ public final class Conversation: ObservableObject {
         let mode = options.conversationOverrides.textOnly ? "text-only" : "voice"
         logger.info("Starting \(mode) conversation", context: activeContext)
 
-        options.onCanSendFeedbackChange?(false)
+        callbacks.onCanSendFeedbackChange?(false)
         setupAgentStateManager()
 
         connectionManager.onEventReceived = { [weak self, weak connectionManager] event in
@@ -472,13 +475,13 @@ public final class Conversation: ObservableObject {
         startupMetrics = failure.metrics
         state = .idle
         updateStartupState(.failed(failure.reason, failure.metrics))
-        options.onError?(failure.error)
+        callbacks.onError?(failure.error)
 
         if suggestLocalNetworkPermission,
            case .room = failure.reason,
            LocalNetworkPermissionMonitor.shared.shouldSuggestLocalNetworkPermission()
         {
-            options.onError?(ConversationError.localNetworkPermissionRequired)
+            callbacks.onError?(ConversationError.localNetworkPermissionRequired)
         }
     }
 
@@ -517,7 +520,7 @@ public final class Conversation: ObservableObject {
 
         lastAgentEventId = nil
         lastFeedbackSubmittedEventId = nil
-        options.onCanSendFeedbackChange?(false)
+        callbacks.onCanSendFeedbackChange?(false)
         latestAudioEvent = nil
         latestAudioAlignment = nil
     }

--- a/Sources/ElevenLabs/Public/Conversation/ConversationCallbacks.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationCallbacks.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Event hooks for a conversation. Set once when the conversation is created
+public struct ConversationCallbacks: Sendable {
+    /// Called when the agent is ready and the conversation can begin
+    public var onAgentReady: (@Sendable () -> Void)?
+
+    /// Called when the agent disconnects or the conversation ends
+    public var onDisconnect: (@Sendable (DisconnectionReason) -> Void)?
+
+    /// Called whenever the startup state transitions
+    public var onStartupStateChange: (@Sendable (ConversationStartupState) -> Void)?
+
+    /// Called when a startup-related error occurs
+    public var onError: (@Sendable (ConversationError) -> Void)?
+
+    /// Called for each agent response with the associated event identifier.
+    public var onAgentResponse: (@Sendable (_ text: String, _ eventId: Int) -> Void)?
+
+    /// Called when an agent response correction is received.
+    public var onAgentResponseCorrection: (@Sendable (_ original: String, _ corrected: String, _ eventId: Int) -> Void)?
+
+    /// Called when agent response metadata is received.
+    public var onAgentResponseMetadata: (@Sendable (_ metadataData: Data, _ eventId: Int) -> Void)?
+
+    /// Called for each user transcript event.
+    public var onUserTranscript: (@Sendable (_ text: String, _ eventId: Int) -> Void)?
+
+    /// Called when conversation metadata arrives.
+    public var onConversationMetadata: (@Sendable (ConversationMetadataEvent) -> Void)?
+
+    /// Called when the agent emits a tool response event.
+    public var onAgentToolResponse: (@Sendable (AgentToolResponseEvent) -> Void)?
+
+    /// Called when the agent requests a tool execution.
+    public var onAgentToolRequest: (@Sendable (AgentToolRequestEvent) -> Void)?
+
+    /// Called when the agent detects an interruption.
+    public var onInterruption: (@Sendable (_ eventId: Int) -> Void)?
+
+    /// Called whenever a VAD score is emitted.
+    public var onVadScore: (@Sendable (_ score: Double) -> Void)?
+
+    /// Called when audio alignment metadata is emitted.
+    public var onAudioAlignment: (@Sendable (AudioAlignment) -> Void)?
+
+    /// Called when feedback availability changes.
+    public var onCanSendFeedbackChange: (@Sendable (Bool) -> Void)?
+
+    /// Called when a client tool call is received without a registered handler.
+    public var onUnhandledClientToolCall: (@Sendable (ClientToolCallEvent) -> Void)?
+
+    /// Called whenever the agent state changes (event-based mode only).
+    public var onAgentStateChange: (@Sendable (ElevenLabs.AgentState) -> Void)?
+
+    public init(
+        onAgentReady: (@Sendable () -> Void)? = nil,
+        onDisconnect: (@Sendable (DisconnectionReason) -> Void)? = nil,
+        onStartupStateChange: (@Sendable (ConversationStartupState) -> Void)? = nil,
+        onError: (@Sendable (ConversationError) -> Void)? = nil,
+        onAgentResponse: (@Sendable (_ text: String, _ eventId: Int) -> Void)? = nil,
+        onAgentResponseCorrection: (@Sendable (_ original: String, _ corrected: String, _ eventId: Int) -> Void)? = nil,
+        onAgentResponseMetadata: (@Sendable (_ metadataData: Data, _ eventId: Int) -> Void)? = nil,
+        onUserTranscript: (@Sendable (_ text: String, _ eventId: Int) -> Void)? = nil,
+        onConversationMetadata: (@Sendable (ConversationMetadataEvent) -> Void)? = nil,
+        onAgentToolResponse: (@Sendable (AgentToolResponseEvent) -> Void)? = nil,
+        onAgentToolRequest: (@Sendable (AgentToolRequestEvent) -> Void)? = nil,
+        onInterruption: (@Sendable (_ eventId: Int) -> Void)? = nil,
+        onVadScore: (@Sendable (_ score: Double) -> Void)? = nil,
+        onAudioAlignment: (@Sendable (AudioAlignment) -> Void)? = nil,
+        onCanSendFeedbackChange: (@Sendable (Bool) -> Void)? = nil,
+        onUnhandledClientToolCall: (@Sendable (ClientToolCallEvent) -> Void)? = nil,
+        onAgentStateChange: (@Sendable (ElevenLabs.AgentState) -> Void)? = nil
+    ) {
+        self.onAgentReady = onAgentReady
+        self.onDisconnect = onDisconnect
+        self.onStartupStateChange = onStartupStateChange
+        self.onError = onError
+        self.onAgentResponse = onAgentResponse
+        self.onAgentResponseCorrection = onAgentResponseCorrection
+        self.onAgentResponseMetadata = onAgentResponseMetadata
+        self.onUserTranscript = onUserTranscript
+        self.onConversationMetadata = onConversationMetadata
+        self.onAgentToolResponse = onAgentToolResponse
+        self.onAgentToolRequest = onAgentToolRequest
+        self.onInterruption = onInterruption
+        self.onVadScore = onVadScore
+        self.onAudioAlignment = onAudioAlignment
+        self.onCanSendFeedbackChange = onCanSendFeedbackChange
+        self.onUnhandledClientToolCall = onUnhandledClientToolCall
+        self.onAgentStateChange = onAgentStateChange
+    }
+}

--- a/Sources/ElevenLabs/Public/Conversation/ConversationConfig.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationConfig.swift
@@ -19,15 +19,6 @@ public struct ConversationConfig: Sendable {
     /// Optional environment for the agent (defaults to production when nil)
     public var environment: String?
 
-    /// Called when the agent is ready and the conversation can begin
-    public var onAgentReady: (@Sendable () -> Void)?
-
-    /// Called when the agent disconnects or the conversation ends
-    public var onDisconnect: (@Sendable (DisconnectionReason) -> Void)?
-
-    /// Called whenever the startup state transitions
-    public var onStartupStateChange: (@Sendable (ConversationStartupState) -> Void)?
-
     /// Controls timings and retry behavior for the initialization handshake
     public var startupConfiguration: ConversationStartupConfiguration
 
@@ -37,54 +28,9 @@ public struct ConversationConfig: Sendable {
     /// Controls LiveKit peer connection behaviour, including ICE policies.
     public var networkConfiguration: LiveKitNetworkConfiguration
 
-    /// Called when a startup-related error occurs
-    public var onError: (@Sendable (ConversationError) -> Void)?
-
-    /// Called when LiveKit detects speech activity while muted.
-    public var onSpeechActivity: (@Sendable (SpeechActivityEvent) -> Void)?
-
-    /// Called for each agent response with the associated event identifier.
-    public var onAgentResponse: (@Sendable (_ text: String, _ eventId: Int) -> Void)?
-
-    /// Called when an agent response correction is received.
-    public var onAgentResponseCorrection: (@Sendable (_ original: String, _ corrected: String, _ eventId: Int) -> Void)?
-
-    /// Called when agent response metadata is received.
-    public var onAgentResponseMetadata: (@Sendable (_ metadataData: Data, _ eventId: Int) -> Void)?
-
-    /// Called for each user transcript event.
-    public var onUserTranscript: (@Sendable (_ text: String, _ eventId: Int) -> Void)?
-
-    /// Called when conversation metadata arrives.
-    public var onConversationMetadata: (@Sendable (ConversationMetadataEvent) -> Void)?
-
-    /// Called when the agent emits a tool response event.
-    public var onAgentToolResponse: (@Sendable (AgentToolResponseEvent) -> Void)?
-
-    /// Called when the agent requests a tool execution.
-    public var onAgentToolRequest: (@Sendable (AgentToolRequestEvent) -> Void)?
-
-    /// Called when the agent detects an interruption.
-    public var onInterruption: (@Sendable (_ eventId: Int) -> Void)?
-
-    /// Called whenever a VAD score is emitted.
-    public var onVadScore: (@Sendable (_ score: Double) -> Void)?
-
-    /// Called when audio alignment metadata is emitted.
-    public var onAudioAlignment: (@Sendable (AudioAlignment) -> Void)?
-
-    /// Called when feedback availability changes.
-    public var onCanSendFeedbackChange: (@Sendable (Bool) -> Void)?
-
-    /// Called when a client tool call is received without a registered handler.
-    public var onUnhandledClientToolCall: (@Sendable (ClientToolCallEvent) -> Void)?
-
     /// When provided, agent state is computed from VAD scores and protocol events
     /// instead of relying on LiveKit's isSpeaking detection.
     public var agentStateConfiguration: AgentStateConfiguration?
-
-    /// Called whenever the agent state changes (event-based mode only).
-    public var onAgentStateChange: (@Sendable (ElevenLabs.AgentState) -> Void)?
 
     public init(
         agentOverrides: AgentOverrides? = nil,
@@ -94,28 +40,10 @@ public struct ConversationConfig: Sendable {
         dynamicVariables: [String: String]? = nil,
         userId: String? = nil,
         environment: String? = nil,
-        onAgentReady: (@Sendable () -> Void)? = nil,
-        onDisconnect: (@Sendable (DisconnectionReason) -> Void)? = nil,
-        onStartupStateChange: (@Sendable (ConversationStartupState) -> Void)? = nil,
         startupConfiguration: ConversationStartupConfiguration = .default,
         audioConfiguration: AudioPipelineConfiguration? = nil,
         networkConfiguration: LiveKitNetworkConfiguration = .default,
-        onError: (@Sendable (ConversationError) -> Void)? = nil,
-        onSpeechActivity: (@Sendable (SpeechActivityEvent) -> Void)? = nil,
-        onAgentResponse: (@Sendable (_ text: String, _ eventId: Int) -> Void)? = nil,
-        onAgentResponseCorrection: (@Sendable (_ original: String, _ corrected: String, _ eventId: Int) -> Void)? = nil,
-        onAgentResponseMetadata: (@Sendable (_ metadataData: Data, _ eventId: Int) -> Void)? = nil,
-        onUserTranscript: (@Sendable (_ text: String, _ eventId: Int) -> Void)? = nil,
-        onConversationMetadata: (@Sendable (ConversationMetadataEvent) -> Void)? = nil,
-        onAgentToolResponse: (@Sendable (AgentToolResponseEvent) -> Void)? = nil,
-        onAgentToolRequest: (@Sendable (AgentToolRequestEvent) -> Void)? = nil,
-        onInterruption: (@Sendable (_ eventId: Int) -> Void)? = nil,
-        onVadScore: (@Sendable (_ score: Double) -> Void)? = nil,
-        onAudioAlignment: (@Sendable (AudioAlignment) -> Void)? = nil,
-        onCanSendFeedbackChange: (@Sendable (Bool) -> Void)? = nil,
-        onUnhandledClientToolCall: (@Sendable (ClientToolCallEvent) -> Void)? = nil,
-        agentStateConfiguration: AgentStateConfiguration? = nil,
-        onAgentStateChange: (@Sendable (ElevenLabs.AgentState) -> Void)? = nil
+        agentStateConfiguration: AgentStateConfiguration? = nil
     ) {
         self.agentOverrides = agentOverrides
         self.ttsOverrides = ttsOverrides
@@ -124,28 +52,10 @@ public struct ConversationConfig: Sendable {
         self.dynamicVariables = dynamicVariables
         self.userId = userId
         self.environment = environment
-        self.onAgentReady = onAgentReady
-        self.onDisconnect = onDisconnect
-        self.onStartupStateChange = onStartupStateChange
         self.startupConfiguration = startupConfiguration
         self.audioConfiguration = audioConfiguration
         self.networkConfiguration = networkConfiguration
-        self.onError = onError
-        self.onSpeechActivity = onSpeechActivity
-        self.onAgentResponse = onAgentResponse
-        self.onAgentResponseCorrection = onAgentResponseCorrection
-        self.onAgentResponseMetadata = onAgentResponseMetadata
-        self.onUserTranscript = onUserTranscript
-        self.onConversationMetadata = onConversationMetadata
-        self.onAgentToolResponse = onAgentToolResponse
-        self.onAgentToolRequest = onAgentToolRequest
-        self.onInterruption = onInterruption
-        self.onVadScore = onVadScore
-        self.onAudioAlignment = onAudioAlignment
-        self.onCanSendFeedbackChange = onCanSendFeedbackChange
-        self.onUnhandledClientToolCall = onUnhandledClientToolCall
         self.agentStateConfiguration = agentStateConfiguration
-        self.onAgentStateChange = onAgentStateChange
     }
 }
 
@@ -213,28 +123,10 @@ extension ConversationConfig {
             dynamicVariables: dynamicVariables,
             userId: userId,
             environment: environment,
-            onAgentReady: onAgentReady,
-            onDisconnect: onDisconnect,
-            onStartupStateChange: onStartupStateChange,
             startupConfiguration: startupConfiguration,
             audioConfiguration: audioConfiguration,
             networkConfiguration: networkConfiguration,
-            onError: onError,
-            onSpeechActivity: onSpeechActivity,
-            onAgentResponse: onAgentResponse,
-            onAgentResponseCorrection: onAgentResponseCorrection,
-            onAgentResponseMetadata: onAgentResponseMetadata,
-            onUserTranscript: onUserTranscript,
-            onConversationMetadata: onConversationMetadata,
-            onAgentToolResponse: onAgentToolResponse,
-            onAgentToolRequest: onAgentToolRequest,
-            onInterruption: onInterruption,
-            onVadScore: onVadScore,
-            onAudioAlignment: onAudioAlignment,
-            onCanSendFeedbackChange: onCanSendFeedbackChange,
-            onUnhandledClientToolCall: onUnhandledClientToolCall,
-            agentStateConfiguration: agentStateConfiguration,
-            onAgentStateChange: onAgentStateChange
+            agentStateConfiguration: agentStateConfiguration
         )
     }
 }

--- a/Sources/ElevenLabs/Public/Conversation/ConversationOptions.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationOptions.swift
@@ -22,15 +22,6 @@ public struct ConversationOptions: Sendable {
     /// How to handle microphone setup failures during connection
     public var microphoneFailureHandling: MicrophoneFailureHandling
 
-    /// Called when the agent is ready and the conversation can begin
-    public var onAgentReady: (@Sendable () -> Void)?
-
-    /// Called when the agent disconnects or the conversation ends
-    public var onDisconnect: (@Sendable (DisconnectionReason) -> Void)?
-
-    /// Called whenever the startup state transitions
-    public var onStartupStateChange: (@Sendable (ConversationStartupState) -> Void)?
-
     /// Controls timings and retry behavior for the initialization handshake
     public var startupConfiguration: ConversationStartupConfiguration
 
@@ -40,54 +31,9 @@ public struct ConversationOptions: Sendable {
     /// Controls LiveKit peer connection behaviour, including ICE policies.
     public var networkConfiguration: LiveKitNetworkConfiguration
 
-    /// Called when a startup-related error occurs
-    public var onError: (@Sendable (ConversationError) -> Void)?
-
-    /// Called when LiveKit detects speech activity while muted.
-    public var onSpeechActivity: (@Sendable (SpeechActivityEvent) -> Void)?
-
-    /// Called for each agent response (finalized transcript) with its event identifier.
-    public var onAgentResponse: (@Sendable (_ text: String, _ eventId: Int) -> Void)?
-
-    /// Called when an agent response is corrected.
-    public var onAgentResponseCorrection: (@Sendable (_ original: String, _ corrected: String, _ eventId: Int) -> Void)?
-
-    /// Called when agent response metadata is received.
-    public var onAgentResponseMetadata: (@Sendable (_ metadataData: Data, _ eventId: Int) -> Void)?
-
-    /// Called for each user transcript event emitted by the server.
-    public var onUserTranscript: (@Sendable (_ text: String, _ eventId: Int) -> Void)?
-
-    /// Called whenever conversation metadata is received.
-    public var onConversationMetadata: (@Sendable (ConversationMetadataEvent) -> Void)?
-
-    /// Called when the agent issues a tool response.
-    public var onAgentToolResponse: (@Sendable (AgentToolResponseEvent) -> Void)?
-
-    /// Called when the agent requests a tool execution.
-    public var onAgentToolRequest: (@Sendable (AgentToolRequestEvent) -> Void)?
-
-    /// Called when the agent detects an interruption.
-    public var onInterruption: (@Sendable (_ eventId: Int) -> Void)?
-
-    /// Called whenever the server emits a VAD score.
-    public var onVadScore: (@Sendable (_ score: Double) -> Void)?
-
-    /// Called when the agent emits audio alignment metadata for spoken words.
-    public var onAudioAlignment: (@Sendable (AudioAlignment) -> Void)?
-
-    /// Called when the client should enable/disable feedback UI.
-    public var onCanSendFeedbackChange: (@Sendable (Bool) -> Void)?
-
-    /// Called when an unhandled client tool call is received.
-    public var onUnhandledClientToolCall: (@Sendable (ClientToolCallEvent) -> Void)?
-
     /// When provided, agent state is computed from VAD scores and protocol events
     /// instead of relying on LiveKit's isSpeaking detection.
     public var agentStateConfiguration: AgentStateConfiguration?
-
-    /// Called whenever the agent state changes (event-based mode only).
-    public var onAgentStateChange: (@Sendable (ElevenLabs.AgentState) -> Void)?
 
     public init(
         conversationOverrides: ConversationOverrides = .init(),
@@ -98,28 +44,10 @@ public struct ConversationOptions: Sendable {
         userId: String? = nil,
         environment: String? = nil,
         microphoneFailureHandling: MicrophoneFailureHandling = .throwError,
-        onAgentReady: (@Sendable () -> Void)? = nil,
-        onDisconnect: (@Sendable (DisconnectionReason) -> Void)? = nil,
-        onStartupStateChange: (@Sendable (ConversationStartupState) -> Void)? = nil,
         startupConfiguration: ConversationStartupConfiguration = .default,
         audioConfiguration: AudioPipelineConfiguration? = nil,
         networkConfiguration: LiveKitNetworkConfiguration = .default,
-        onError: (@Sendable (ConversationError) -> Void)? = nil,
-        onSpeechActivity: (@Sendable (SpeechActivityEvent) -> Void)? = nil,
-        onAgentResponse: (@Sendable (_ text: String, _ eventId: Int) -> Void)? = nil,
-        onAgentResponseCorrection: (@Sendable (_ original: String, _ corrected: String, _ eventId: Int) -> Void)? = nil,
-        onAgentResponseMetadata: (@Sendable (_ metadataData: Data, _ eventId: Int) -> Void)? = nil,
-        onUserTranscript: (@Sendable (_ text: String, _ eventId: Int) -> Void)? = nil,
-        onConversationMetadata: (@Sendable (ConversationMetadataEvent) -> Void)? = nil,
-        onAgentToolResponse: (@Sendable (AgentToolResponseEvent) -> Void)? = nil,
-        onAgentToolRequest: (@Sendable (AgentToolRequestEvent) -> Void)? = nil,
-        onInterruption: (@Sendable (_ eventId: Int) -> Void)? = nil,
-        onVadScore: (@Sendable (_ score: Double) -> Void)? = nil,
-        onAudioAlignment: (@Sendable (AudioAlignment) -> Void)? = nil,
-        onCanSendFeedbackChange: (@Sendable (Bool) -> Void)? = nil,
-        onUnhandledClientToolCall: (@Sendable (ClientToolCallEvent) -> Void)? = nil,
-        agentStateConfiguration: AgentStateConfiguration? = nil,
-        onAgentStateChange: (@Sendable (ElevenLabs.AgentState) -> Void)? = nil
+        agentStateConfiguration: AgentStateConfiguration? = nil
     ) {
         self.conversationOverrides = conversationOverrides
         self.agentOverrides = agentOverrides
@@ -129,28 +57,10 @@ public struct ConversationOptions: Sendable {
         self.userId = userId
         self.environment = environment
         self.microphoneFailureHandling = microphoneFailureHandling
-        self.onAgentReady = onAgentReady
-        self.onDisconnect = onDisconnect
-        self.onStartupStateChange = onStartupStateChange
         self.startupConfiguration = startupConfiguration
         self.audioConfiguration = audioConfiguration
         self.networkConfiguration = networkConfiguration
-        self.onError = onError
-        self.onSpeechActivity = onSpeechActivity
-        self.onAgentResponse = onAgentResponse
-        self.onAgentResponseCorrection = onAgentResponseCorrection
-        self.onAgentResponseMetadata = onAgentResponseMetadata
-        self.onUserTranscript = onUserTranscript
-        self.onConversationMetadata = onConversationMetadata
-        self.onAgentToolResponse = onAgentToolResponse
-        self.onAgentToolRequest = onAgentToolRequest
-        self.onInterruption = onInterruption
-        self.onVadScore = onVadScore
-        self.onAudioAlignment = onAudioAlignment
-        self.onCanSendFeedbackChange = onCanSendFeedbackChange
-        self.onUnhandledClientToolCall = onUnhandledClientToolCall
         self.agentStateConfiguration = agentStateConfiguration
-        self.onAgentStateChange = onAgentStateChange
     }
 
     public static let `default` = ConversationOptions()
@@ -166,14 +76,10 @@ extension ConversationOptions {
             dynamicVariables: dynamicVariables,
             userId: userId,
             environment: environment,
-            onAgentReady: onAgentReady,
-            onDisconnect: onDisconnect,
-            onStartupStateChange: onStartupStateChange,
             startupConfiguration: startupConfiguration,
             audioConfiguration: audioConfiguration,
             networkConfiguration: networkConfiguration,
-            onError: onError,
-            onSpeechActivity: onSpeechActivity
+            agentStateConfiguration: agentStateConfiguration
         )
     }
 }

--- a/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
+++ b/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
@@ -41,8 +41,7 @@ public enum ElevenLabs {
     /// - Parameters:
     ///   - agentId: The public ElevenLabs agent ID to connect to
     ///   - config: Optional conversation configuration (voice/text mode, overrides, etc.)
-    ///   - onAgentReady: Optional callback triggered when the agent is ready and conversation can begin
-    ///   - onDisconnect: Optional callback triggered when the agent disconnects or conversation ends
+    ///   - callbacks: Optional event hooks (onAgentReady, onDisconnect, etc.), set once for this conversation
     /// - Returns: An active `Conversation` instance ready for interaction
     /// - Throws: `ConversationError` if connection fails, agent not found, or configuration invalid
     ///
@@ -59,26 +58,24 @@ public enum ElevenLabs {
     /// // Conversation with event handlers
     /// let conversation = try await ElevenLabs.startConversation(
     ///     agentId: "agent_123",
-    ///     onAgentReady: {
-    ///         print("Agent is ready!")
-    ///     },
-    ///     onDisconnect: {
-    ///         print("Agent disconnected")
-    ///     }
+    ///     callbacks: .init(
+    ///         onAgentReady: {
+    ///             print("Agent is ready!")
+    ///         },
+    ///         onDisconnect: { reason in
+    ///             print("Agent disconnected: \(reason)")
+    ///         }
+    ///     )
     /// )
     /// ```
     @MainActor
     public static func startConversation(
         agentId: String,
         config: ConversationConfig = .init(),
-        onAgentReady: (@Sendable () -> Void)? = nil,
-        onDisconnect: (@Sendable (DisconnectionReason) -> Void)? = nil
+        callbacks: ConversationCallbacks = .init()
     ) async throws -> Conversation {
         let authConfig = ConversationCredentials.publicAgent(id: agentId, environment: config.environment)
-        var updatedConfig = config
-        updatedConfig.onAgentReady = onAgentReady
-        updatedConfig.onDisconnect = onDisconnect
-        return try await startConversation(auth: authConfig, config: updatedConfig)
+        return try await startConversation(auth: authConfig, config: config, callbacks: callbacks)
     }
 
     /// Start a conversation using a conversation token from your backend - for private agents.
@@ -91,8 +88,7 @@ public enum ElevenLabs {
     /// - Parameters:
     ///   - conversationToken: The conversation token from your backend
     ///   - config: Optional conversation configuration (voice/text mode, overrides, etc.)
-    ///   - onAgentReady: Optional callback triggered when the agent is ready and conversation can begin
-    ///   - onDisconnect: Optional callback triggered when the agent disconnects or conversation ends
+    ///   - callbacks: Optional event hooks (onAgentReady, onDisconnect, etc.), set once for this conversation
     /// - Returns: An active `Conversation` instance ready for interaction
     /// - Throws: `ConversationError` if connection fails or token is invalid
     ///
@@ -112,14 +108,10 @@ public enum ElevenLabs {
     public static func startConversation(
         conversationToken: String,
         config: ConversationConfig = .init(),
-        onAgentReady: (@Sendable () -> Void)? = nil,
-        onDisconnect: (@Sendable (DisconnectionReason) -> Void)? = nil
+        callbacks: ConversationCallbacks = .init()
     ) async throws -> Conversation {
         let authConfig = ConversationCredentials.conversationToken(conversationToken, environment: config.environment)
-        var updatedConfig = config
-        updatedConfig.onAgentReady = onAgentReady
-        updatedConfig.onDisconnect = onDisconnect
-        return try await startConversation(auth: authConfig, config: updatedConfig)
+        return try await startConversation(auth: authConfig, config: config, callbacks: callbacks)
     }
 
     /// Start a conversation using a custom token provider - for advanced authentication scenarios.
@@ -129,8 +121,7 @@ public enum ElevenLabs {
     /// - Parameters:
     ///   - tokenProvider: An async closure that returns a conversation token
     ///   - config: Optional conversation configuration (voice/text mode, overrides, etc.)
-    ///   - onAgentReady: Optional callback triggered when the agent is ready and conversation can begin
-    ///   - onDisconnect: Optional callback triggered when the agent disconnects or conversation ends
+    ///   - callbacks: Optional event hooks (onAgentReady, onDisconnect, etc.), set once for this conversation
     /// - Returns: An active `Conversation` instance ready for interaction
     /// - Throws: `ConversationError` if connection fails or token provider throws
     ///
@@ -149,14 +140,10 @@ public enum ElevenLabs {
     public static func startConversation(
         tokenProvider: @escaping @Sendable () async throws -> String,
         config: ConversationConfig = .init(),
-        onAgentReady: (@Sendable () -> Void)? = nil,
-        onDisconnect: (@Sendable (DisconnectionReason) -> Void)? = nil
+        callbacks: ConversationCallbacks = .init()
     ) async throws -> Conversation {
         let authConfig = ConversationCredentials.customTokenProvider(tokenProvider, environment: config.environment)
-        var updatedConfig = config
-        updatedConfig.onAgentReady = onAgentReady
-        updatedConfig.onDisconnect = onDisconnect
-        return try await startConversation(auth: authConfig, config: updatedConfig)
+        return try await startConversation(auth: authConfig, config: config, callbacks: callbacks)
     }
 
     /// Start a text-only conversation using a signed WebSocket URL from your backend.
@@ -167,17 +154,14 @@ public enum ElevenLabs {
     public static func startConversation(
         signedWebSocketURL: String,
         config: ConversationConfig = .init(conversationOverrides: .init(textOnly: true)),
-        onAgentReady: (@Sendable () -> Void)? = nil,
-        onDisconnect: (@Sendable (DisconnectionReason) -> Void)? = nil
+        callbacks: ConversationCallbacks = .init()
     ) async throws -> Conversation {
         let authConfig = try ConversationCredentials.signedWebSocketURL(signedWebSocketURL)
         var updatedConfig = config
         var overrides = updatedConfig.conversationOverrides ?? ConversationOverrides()
         overrides.textOnly = true
         updatedConfig.conversationOverrides = overrides
-        updatedConfig.onAgentReady = onAgentReady
-        updatedConfig.onDisconnect = onDisconnect
-        return try await startConversation(auth: authConfig, config: updatedConfig)
+        return try await startConversation(auth: authConfig, config: updatedConfig, callbacks: callbacks)
     }
 
     /// Advanced: Start a conversation with full authentication control.
@@ -192,10 +176,11 @@ public enum ElevenLabs {
     @MainActor
     public static func startConversation(
         auth: ConversationCredentials,
-        config: ConversationConfig = .init()
+        config: ConversationConfig = .init(),
+        callbacks: ConversationCallbacks = .init()
     ) async throws -> Conversation {
         let options = config.toConversationOptions()
-        let conversation = createConversation(options: options)
+        let conversation = createConversation(options: options, callbacks: callbacks)
         try await conversation.startConversation(
             auth: auth, options: options
         )
@@ -206,8 +191,11 @@ public enum ElevenLabs {
 
     /// Creates a new Conversation instance with proper dependency injection.
     @MainActor
-    private static func createConversation(options: ConversationOptions = .default) -> Conversation {
-        Conversation(dependencyProvider: Dependencies(), options: options)
+    private static func createConversation(
+        options: ConversationOptions = .default,
+        callbacks: ConversationCallbacks = .init()
+    ) -> Conversation {
+        Conversation(dependencyProvider: Dependencies(), options: options, callbacks: callbacks)
     }
 
     // MARK: - Re-exports

--- a/Tests/ElevenLabsTests/Unit/ConversationEventHandlerTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationEventHandlerTests.swift
@@ -29,7 +29,7 @@ final class ConversationEventHandlerTests: XCTestCase {
 
         conversation = Conversation(
             dependencyProvider: mockDependencyProvider,
-            options: ConversationOptions(
+            callbacks: ConversationCallbacks(
                 onUserTranscript: { transcript, eventId in
                     Task { await receivedTranscripts.append((transcript, eventId)) }
                     expectation.fulfill()
@@ -59,7 +59,7 @@ final class ConversationEventHandlerTests: XCTestCase {
 
         conversation = Conversation(
             dependencyProvider: mockDependencyProvider,
-            options: ConversationOptions(
+            callbacks: ConversationCallbacks(
                 onAgentResponse: { response, eventId in
                     XCTAssertEqual(response, "I am an AI")
                     XCTAssertEqual(eventId, 456)
@@ -199,7 +199,7 @@ final class ConversationEventHandlerTests: XCTestCase {
 
         conversation = Conversation(
             dependencyProvider: mockDependencyProvider,
-            options: ConversationOptions(
+            callbacks: ConversationCallbacks(
                 onInterruption: { eventId in
                     XCTAssertEqual(eventId, 789)
                     expectation.fulfill()

--- a/Tests/ElevenLabsTests/Unit/ConversationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationTests.swift
@@ -20,7 +20,7 @@ final class ConversationTests: XCTestCase {
             webRTCConnectionManager: mockWebRTCConnectionManager,
             webSocketConnectionManager: mockWebSocketConnectionManager
         )
-        conversation = Conversation(dependencyProvider: dependencyProvider)
+        conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: makeCallbacks())
         await capturedErrors.reset()
     }
 
@@ -42,16 +42,15 @@ final class ConversationTests: XCTestCase {
     func testStartConversationSuccessUpdatesStartupState() async throws {
         let stateExpectation = expectation(description: "startup becomes active")
 
-        let options = makeConfig(
-            onStartupStateChange: { state in
-                if case .active = state {
-                    stateExpectation.fulfill()
-                }
+        let options = makeConfig()
+        let callbacks = makeCallbacks(onStartupStateChange: { state in
+            if case .active = state {
+                stateExpectation.fulfill()
             }
-        )
+        })
+        let conversation = Conversation(dependencyProvider: dependencyProvider, options: options, callbacks: callbacks)
 
         let startTask = Task {
-            guard let conversation = self.conversation else { return }
             try await conversation.startConversation(
                 auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
                 options: options
@@ -522,16 +521,16 @@ final class ConversationTests: XCTestCase {
         let receivedResponses = ValueRecorder<(String, Int)>()
         let feedbackStates = ValueRecorder<Bool>()
 
-        let options = makeConfig(configure: { options in
-            options.onAgentResponse = { text, eventId in
+        let callbacks = makeCallbacks(configure: { callbacks in
+            callbacks.onAgentResponse = { text, eventId in
                 Task { await receivedResponses.append((text, eventId)) }
             }
-            options.onCanSendFeedbackChange = { canSend in
+            callbacks.onCanSendFeedbackChange = { canSend in
                 Task { await feedbackStates.append(canSend) }
             }
         })
 
-        let conversation = Conversation(dependencyProvider: dependencyProvider, options: options)
+        let conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: callbacks)
 
         // Set up mock connection manager with a room and active state so sendFeedback can publish
         mockWebRTCConnectionManager.room = Room()
@@ -563,13 +562,13 @@ final class ConversationTests: XCTestCase {
 
     func testVadScoreCallbackReceivesScores() async {
         let vadScores = ValueRecorder<Double>()
-        let options = makeConfig(configure: { options in
-            options.onVadScore = { score in
+        let callbacks = makeCallbacks(configure: { callbacks in
+            callbacks.onVadScore = { score in
                 Task { await vadScores.append(score) }
             }
         })
 
-        let conversation = Conversation(dependencyProvider: dependencyProvider, options: options)
+        let conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: callbacks)
         await conversation._testing_handleIncomingEvent(IncomingEvent.vadScore(VadScoreEvent(vadScore: 0.87)))
 
         // Allow async callbacks to complete
@@ -581,13 +580,13 @@ final class ConversationTests: XCTestCase {
 
     func testAgentToolResponseCallbackReceivesEvent() async {
         let capturedToolNames = ValueRecorder<String>()
-        let options = makeConfig(configure: { options in
-            options.onAgentToolResponse = { (event: AgentToolResponseEvent) in
+        let callbacks = makeCallbacks(configure: { callbacks in
+            callbacks.onAgentToolResponse = { (event: AgentToolResponseEvent) in
                 Task { await capturedToolNames.append(event.toolName) }
             }
         })
 
-        let conversation = Conversation(dependencyProvider: dependencyProvider, options: options)
+        let conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: callbacks)
         let toolEvent = AgentToolResponseEvent(toolName: "end_call", toolCallId: "id", toolType: "action", isError: false, eventId: 10)
 
         await conversation._testing_handleIncomingEvent(IncomingEvent.agentToolResponse(toolEvent))
@@ -603,16 +602,16 @@ final class ConversationTests: XCTestCase {
         let interruptionIds = ValueRecorder<Int>()
         let feedbackStates = ValueRecorder<Bool>()
 
-        let options = makeConfig(configure: { options in
-            options.onInterruption = { id in
+        let callbacks = makeCallbacks(configure: { callbacks in
+            callbacks.onInterruption = { id in
                 Task { await interruptionIds.append(id) }
             }
-            options.onCanSendFeedbackChange = { canSend in
+            callbacks.onCanSendFeedbackChange = { canSend in
                 Task { await feedbackStates.append(canSend) }
             }
         })
 
-        let conversation = Conversation(dependencyProvider: dependencyProvider, options: options)
+        let conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: callbacks)
         await conversation._testing_handleIncomingEvent(IncomingEvent.interruption(InterruptionEvent(eventId: 7)))
 
         // Allow async callbacks to complete
@@ -672,14 +671,15 @@ final class ConversationTests: XCTestCase {
 
     func testAgentDisconnectEndsConversation() async throws {
         let disconnectReasons = ValueRecorder<DisconnectionReason>()
-        let options = makeConfig(configure: { options in
-            options.onDisconnect = { reason in
+        let options = makeConfig()
+        let callbacks = makeCallbacks(configure: { callbacks in
+            callbacks.onDisconnect = { reason in
                 Task { await disconnectReasons.append(reason) }
             }
         })
+        let conversation = Conversation(dependencyProvider: dependencyProvider, options: options, callbacks: callbacks)
 
         let startTask = Task {
-            guard let conversation = self.conversation else { return }
             try await conversation.startConversation(
                 auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
                 options: options
@@ -768,20 +768,25 @@ actor ValueRecorder<Value> {
 extension ConversationTests {
     private func makeConfig(
         startupConfiguration: ConversationStartupConfiguration = .default,
-        onStartupStateChange: (@Sendable (ConversationStartupState) -> Void)? = nil,
         configure: ((inout ConversationOptions) -> Void)? = nil
     ) -> ConversationOptions {
-        var options = ConversationOptions(
-            onStartupStateChange: onStartupStateChange,
-            startupConfiguration: startupConfiguration
-        )
+        var options = ConversationOptions(startupConfiguration: startupConfiguration)
+        configure?(&options)
+        return options
+    }
 
-        options.onError = { [capturedErrors] error in
+    private func makeCallbacks(
+        onStartupStateChange: (@Sendable (ConversationStartupState) -> Void)? = nil,
+        configure: ((inout ConversationCallbacks) -> Void)? = nil
+    ) -> ConversationCallbacks {
+        var callbacks = ConversationCallbacks(onStartupStateChange: onStartupStateChange)
+
+        callbacks.onError = { [capturedErrors] error in
             Task { await capturedErrors.append(error) }
         }
 
-        configure?(&options)
-        return options
+        configure?(&callbacks)
+        return callbacks
     }
 }
 

--- a/Tests/ElevenLabsTests/Unit/ErrorHandlingIntegrationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ErrorHandlingIntegrationTests.swift
@@ -35,7 +35,8 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
         let errorExpectation = expectation(description: "Error callback should be called")
         let collector = ErrorCollector()
 
-        let options = ConversationOptions(
+        let options = ConversationOptions()
+        let callbacks = ConversationCallbacks(
             onStartupStateChange: { state in
                 print("📊 Startup state: \(state)")
                 Task { await collector.addState(state) }
@@ -49,7 +50,8 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
 
         let conversation = Conversation(
             dependencyProvider: Dependencies(),
-            options: options
+            options: options,
+            callbacks: callbacks
         )
         self.conversation = conversation
 
@@ -95,6 +97,10 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
         let networkConfig = LiveKitNetworkConfiguration(strategy: .automatic)
 
         let options = ConversationOptions(
+            startupConfiguration: startupConfig,
+            networkConfiguration: networkConfig
+        )
+        let callbacks = ConversationCallbacks(
             onAgentReady: {
                 print("✅ Agent ready!")
                 readyExpectation.fulfill()
@@ -103,8 +109,6 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
                 print("📊 Startup state: \(state)")
                 Task { await collector.addState(state) }
             },
-            startupConfiguration: startupConfig,
-            networkConfiguration: networkConfig,
             onError: { error in
                 print("❌ Unexpected error in success test: \(error)")
                 Task { await collector.addError(error) }
@@ -113,7 +117,8 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
 
         let conversation = Conversation(
             dependencyProvider: Dependencies(),
-            options: options
+            options: options,
+            callbacks: callbacks
         )
         self.conversation = conversation
 
@@ -171,11 +176,13 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
         let networkConfig = LiveKitNetworkConfiguration(strategy: .automatic)
 
         let options = ConversationOptions(
+            startupConfiguration: startupConfig,
+            networkConfiguration: networkConfig
+        )
+        let callbacks = ConversationCallbacks(
             onAgentReady: {
                 readyExpectation.fulfill()
             },
-            startupConfiguration: startupConfig,
-            networkConfiguration: networkConfig,
             onError: { error in
                 print("❌ Error reported: \(error)")
                 Task { await collector.addError(error) }
@@ -184,7 +191,8 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
 
         let conversation = Conversation(
             dependencyProvider: Dependencies(),
-            options: options
+            options: options,
+            callbacks: callbacks
         )
         self.conversation = conversation
 
@@ -228,11 +236,13 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
             print("\n--- Attempt \(attempt) ---")
 
             let options = ConversationOptions(
+                startupConfiguration: startupConfig,
+                networkConfiguration: networkConfig
+            )
+            let callbacks = ConversationCallbacks(
                 onStartupStateChange: { state in
                     print("  📊 State: \(state)")
                 },
-                startupConfiguration: startupConfig,
-                networkConfiguration: networkConfig,
                 onError: { error in
                     print("  ❌ Error: \(error)")
                 }
@@ -240,7 +250,8 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
 
             let conversation = Conversation(
                 dependencyProvider: Dependencies(),
-                options: options
+                options: options,
+                callbacks: callbacks
             )
 
             do {
@@ -271,7 +282,8 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
         let errorExpectation = expectation(description: "Should receive error state")
         let collector = ErrorCollector()
 
-        let options = ConversationOptions(
+        let options = ConversationOptions()
+        let callbacks = ConversationCallbacks(
             onStartupStateChange: { state in
                 print("📊 State transition: \(state)")
                 Task { await collector.addState(state) }
@@ -287,7 +299,8 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
 
         let conversation = Conversation(
             dependencyProvider: Dependencies(),
-            options: options
+            options: options,
+            callbacks: callbacks
         )
         self.conversation = conversation
 
@@ -327,7 +340,8 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
         let errorExpectation = expectation(description: "Should receive error")
         let collector = ErrorCollector()
 
-        let options = ConversationOptions(
+        let options = ConversationOptions()
+        let callbacks = ConversationCallbacks(
             onError: { error in
                 print("❌ Token provider error: \(error)")
                 Task { await collector.addError(error) }
@@ -337,7 +351,8 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
 
         let conversation = Conversation(
             dependencyProvider: Dependencies(),
-            options: options
+            options: options,
+            callbacks: callbacks
         )
         self.conversation = conversation
 
@@ -369,7 +384,8 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
         print("ℹ️ This test verifies error callbacks work for network issues")
 
         let collector = ErrorCollector()
-        let options = ConversationOptions(
+        let options = ConversationOptions()
+        let callbacks = ConversationCallbacks(
             onStartupStateChange: { state in
                 print("📊 State: \(state)")
             },
@@ -381,7 +397,8 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
 
         let conversation = Conversation(
             dependencyProvider: Dependencies(),
-            options: options
+            options: options,
+            callbacks: callbacks
         )
         self.conversation = conversation
 
@@ -429,6 +446,10 @@ extension ErrorHandlingIntegrationTests {
         let networkConfig = LiveKitNetworkConfiguration(strategy: .automatic)
 
         let options = ConversationOptions(
+            startupConfiguration: startupConfig,
+            networkConfiguration: networkConfig
+        )
+        let callbacks = ConversationCallbacks(
             onAgentReady: {
                 let timestamp = Self.formatTimestamp()
                 print("✅ [\(timestamp)] AGENT READY")
@@ -444,8 +465,6 @@ extension ErrorHandlingIntegrationTests {
                     await errorCollector.addState(state)
                 }
             },
-            startupConfiguration: startupConfig,
-            networkConfiguration: networkConfig,
             onError: { error in
                 let timestamp = Self.formatTimestamp()
                 print("\n❌ [\(timestamp)] ERROR CALLBACK INVOKED:")
@@ -460,7 +479,8 @@ extension ErrorHandlingIntegrationTests {
 
         let conversation = Conversation(
             dependencyProvider: Dependencies(),
-            options: options
+            options: options,
+            callbacks: callbacks
         )
         self.conversation = conversation
 


### PR DESCRIPTION
Extracting callbacks from `ConversationConfig` into a new `ConversationCallbacks` struct.

Reasons:
 * Callbacks do not belong in ConversationConfig - behaviour vs data
 * ConversationConfig got messy with too many fields

This is for sure a breaking change but easy to migrate manually or with AI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API for all integrators using callbacks on `ConversationConfig` or `startConversation` convenience parameters; behavior is largely a move, except loss of `options.onSpeechActivity` as a second registration path.
> 
> **Overview**
> This PR **splits conversation event hooks out of configuration** into a new public `ConversationCallbacks` type, so `ConversationConfig` / `ConversationOptions` hold only session settings (overrides, startup, audio, network, agent state).
> 
> **API (breaking):** `ElevenLabs.startConversation(...)` now takes an optional `callbacks:` argument instead of embedding handlers in `ConversationConfig` or separate `onAgentReady` / `onDisconnect` parameters. `Conversation` is constructed with `callbacks` fixed at creation; runtime dispatch in `Conversation+Events` and lifecycle paths uses `callbacks` instead of `options`.
> 
> **Narrower audio hook:** `ConversationOptions.onSpeechActivity` is removed; muted-speech activity is wired only through `AudioPipelineConfiguration.onSpeechActivity` (no duplicate handler on options).
> 
> README and `Documentation/Usage.md` examples are updated; unit tests construct `ConversationCallbacks` via new `makeCallbacks()` helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba72dc96b3fe7951843be575d14ecf91c140436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->