### PR TITLE
test: remove _testing_* backdoors from Conversation

### DIFF
--- a/Sources/ElevenLabs/Public/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Conversation.swift
@@ -536,24 +536,6 @@ public final class Conversation: ObservableObject {
         agentStateManager = nil
     }
 
-    // MARK: - Testing Hooks
-
-    @MainActor
-    // swiftlint:disable:next identifier_name
-    func _testing_handleIncomingEvent(_ event: IncomingEvent) async {
-        await handleIncomingEvent(event)
-    }
-
-    // swiftlint:disable:next identifier_name
-    func _testing_setState(_ newState: ConversationState) {
-        state = newState
-    }
-
-    // swiftlint:disable:next identifier_name
-    func _testing_setWebRTCConnectionManager(_ manager: any WebRTCConnectionManaging) {
-        activeConnectionManager = manager
-    }
-
     private func scheduleBackToListening(delay: TimeInterval = 0.5) {
         speakingTimer?.cancel()
         speakingTimer = Task {

--- a/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
+++ b/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
@@ -9,8 +9,18 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
     }
 
     var onDisconnected: (() async -> Void)?
-    var onEventReceived: (@Sendable (IncomingEvent) -> Void)?
+    var onEventReceived: (@Sendable (IncomingEvent) -> Void)? {
+        didSet {
+            if onEventReceived != nil {
+                eventHandlerInstalled?.resume()
+                eventHandlerInstalled = nil
+            }
+        }
+    }
+
     var onRemoteSpeakingChanged: (@Sendable (Bool) -> Void)?
+
+    private var eventHandlerInstalled: CheckedContinuation<Void, Never>?
 
     var room: Room?
 
@@ -34,6 +44,10 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
 
     private var waitContinuation: CheckedContinuation<AgentReadyWaitResult, Never>?
     private var pendingWaitResult: AgentReadyWaitResult?
+
+    /// When `true` (the default), `waitForAgentReady` resolves immediately. Set to `false`
+    /// only when a test needs to drive readiness via `succeedAgentReady`/`timeoutAgentReady`.
+    var autoSucceedAgentReady = true
 
     /// Simulates the full WebRTC startup (token → room → agent → init), driven by
     /// the `tokenError`/`shouldFailConnection`/`publishError` flags and the
@@ -96,6 +110,9 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
             pendingWaitResult = nil
             return pending
         }
+        if autoSucceedAgentReady {
+            return .success(elapsed: 0)
+        }
 
         return await withCheckedContinuation { continuation in
             waitContinuation = continuation
@@ -128,6 +145,17 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
 
     func receive(data: Data) {
         handleIncomingData(data, logger: SDKLogger(logLevel: .error))
+    }
+
+    /// Delivers an already-decoded event directly to the installed handler
+    func deliver(_ event: IncomingEvent) {
+        onEventReceived?(event)
+    }
+
+    /// Suspends until `onEventReceived` is set.
+    func waitForEventHandlerInstalled() async {
+        if onEventReceived != nil { return }
+        await withCheckedContinuation { eventHandlerInstalled = $0 }
     }
 
     func succeedAgentReady(elapsed: TimeInterval = 0.1) {

--- a/Tests/ElevenLabsTests/TestSupport.swift
+++ b/Tests/ElevenLabsTests/TestSupport.swift
@@ -1,0 +1,131 @@
+import Combine
+@testable import ElevenLabs
+import XCTest
+
+extension XCTestCase {
+    /// Waits for a `@Published` property to emit a value matching `predicate`.
+    func waitForPublished<P: Publisher>(
+        _ publisher: P,
+        timeout: TimeInterval = 1.0,
+        until predicate: @escaping (P.Output) -> Bool
+    ) async where P.Failure == Never {
+        let met = expectation(description: "condition met")
+        var cancellable: AnyCancellable?
+        cancellable = publisher.sink { value in
+            if predicate(value) {
+                met.fulfill()
+                cancellable?.cancel()
+            }
+        }
+        await fulfillment(of: [met], timeout: timeout)
+        cancellable?.cancel()
+    }
+
+    /// Waits until `recorder` has at least `count` values, then returns the snapshot.
+    func waitForValues<T>(
+        _ recorder: ValueRecorder<T>,
+        count: Int,
+        timeout: TimeInterval = 1.0
+    ) async -> [T] {
+        let done = expectation(description: "recorder count")
+        Task {
+            await recorder.waitForCount(count)
+            done.fulfill()
+        }
+        await fulfillment(of: [done], timeout: timeout)
+        return await recorder.values()
+    }
+
+    /// Waits until `recorder`'s latest value matches `predicate`, then returns that value.
+    func waitForLastValue<T>(
+        _ recorder: ValueRecorder<T>,
+        timeout: TimeInterval = 1.0,
+        matching predicate: @escaping @Sendable (T) -> Bool
+    ) async -> T? {
+        let done = expectation(description: "recorder last")
+        Task {
+            await recorder.waitForLast(matching: predicate)
+            done.fulfill()
+        }
+        await fulfillment(of: [done], timeout: timeout)
+        return await recorder.last()
+    }
+
+    /// Waits until the mock's `onEventReceived` handler is installed.
+    func waitForEventHandlerInstalled(
+        on mock: MockWebRTCConnectionManager,
+        timeout: TimeInterval = 1.0
+    ) async {
+        let done = expectation(description: "event handler installed")
+        Task {
+            await mock.waitForEventHandlerInstalled()
+            done.fulfill()
+        }
+        await fulfillment(of: [done], timeout: timeout)
+    }
+
+    func XCTAssertThrowsErrorAsync(
+        _ expression: () async throws -> some Sendable,
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        errorHandler: (Error) -> Void = { _ in }
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail(message(), file: file, line: line)
+        } catch {
+            errorHandler(error)
+        }
+    }
+}
+
+actor ValueRecorder<Value> {
+    private var storage: [Value] = []
+    private var countWaiters: [(target: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    private var valueWaiters: [(predicate: @Sendable (Value) -> Bool, continuation: CheckedContinuation<Void, Never>)] = []
+
+    func append(_ value: Value) {
+        storage.append(value)
+        countWaiters.removeAll { waiter in
+            guard storage.count >= waiter.target else { return false }
+            waiter.continuation.resume()
+            return true
+        }
+        valueWaiters.removeAll { waiter in
+            guard waiter.predicate(value) else { return false }
+            waiter.continuation.resume()
+            return true
+        }
+    }
+
+    func reset() {
+        storage.removeAll()
+        let pendingCounts = countWaiters
+        let pendingValues = valueWaiters
+        countWaiters.removeAll()
+        valueWaiters.removeAll()
+        pendingCounts.forEach { $0.continuation.resume() }
+        pendingValues.forEach { $0.continuation.resume() }
+    }
+
+    func values() -> [Value] {
+        storage
+    }
+
+    func last() -> Value? {
+        storage.last
+    }
+
+    /// Suspends until at least `expectedCount` values have been recorded.
+    func waitForCount(_ expectedCount: Int) async {
+        if storage.count >= expectedCount { return }
+        await withCheckedContinuation { countWaiters.append((expectedCount, $0)) }
+    }
+
+    /// Suspends until the most recently recorded value satisfies `predicate`.
+    func waitForLast(matching predicate: @escaping @Sendable (Value) -> Bool) async {
+        if let last = storage.last, predicate(last) { return }
+        await withCheckedContinuation { valueWaiters.append((predicate, $0)) }
+    }
+}

--- a/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
+++ b/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
@@ -1,3 +1,4 @@
+import Combine
 @testable import ElevenLabs
 import Foundation
 import LiveKit
@@ -26,10 +27,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
     // MARK: - Tool Call Tests
 
     func testToolCallLifecycle() async throws {
-        // Set up active state with room first
-        mockWebRTCConnectionManager.room = Room()
-        conversation._testing_setWebRTCConnectionManager(mockWebRTCConnectionManager)
-        conversation._testing_setState(.active(CallInfo(agentId: "test")))
+        try await conversation.startConversation(auth: .publicAgent(id: "test"))
 
         // 1. Receive a tool call
         let toolCall = try ClientToolCallEvent(
@@ -39,20 +37,21 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
             eventId: 1,
             expectsResponse: false
         )
-
-        await conversation._testing_handleIncomingEvent(.clientToolCall(toolCall))
+        mockWebRTCConnectionManager.deliver(.clientToolCall(toolCall))
+        await waitForPublished(conversation.$pendingToolCalls) { $0.contains { $0.toolCallId == "call_123" } }
 
         XCTAssertEqual(conversation.pendingToolCalls.count, 1)
         XCTAssertEqual(conversation.pendingToolCalls.first?.toolCallId, "call_123")
 
         // 2. Send result
+        let payloadCountBeforeResult = mockWebRTCConnectionManager.publishedPayloads.count
         try await conversation.sendToolResult(for: "call_123", result: "success")
 
         // 3. Verify tool is removed from pending list
         XCTAssertTrue(conversation.pendingToolCalls.isEmpty)
 
         // 4. Verify result was published
-        XCTAssertEqual(mockWebRTCConnectionManager.publishedPayloads.count, 1)
+        XCTAssertEqual(mockWebRTCConnectionManager.publishedPayloads.count, payloadCountBeforeResult + 1)
         let lastPayload = mockWebRTCConnectionManager.publishedPayloads.last ?? Data()
         let lastPayloadString = String(data: lastPayload, encoding: .utf8) ?? ""
         XCTAssertTrue(lastPayloadString.contains("call_123"))
@@ -64,9 +63,8 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
             let temperature: Int
             let condition: String
         }
-        mockWebRTCConnectionManager.room = Room()
-        conversation._testing_setWebRTCConnectionManager(mockWebRTCConnectionManager)
-        conversation._testing_setState(.active(CallInfo(agentId: "test")))
+
+        try await conversation.startConversation(auth: .publicAgent(id: "test"))
 
         try await conversation.sendToolResult(
             for: "call_42",
@@ -85,25 +83,33 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
 
     // MARK: - Streaming Message Tests
 
-    func testAgentStreamingMessages() async {
+    func testAgentStreamingMessages() async throws {
+        try await conversation.startConversation(auth: .publicAgent(id: "test"))
+
         // 1. Start streaming
-        let startEvent = AgentChatResponsePartEvent(text: "Hello", type: .start, eventId: 1)
-        await conversation._testing_handleIncomingEvent(.agentChatResponsePart(startEvent))
+        mockWebRTCConnectionManager.deliver(.agentChatResponsePart(
+            AgentChatResponsePartEvent(text: "Hello", type: .start, eventId: 1)
+        ))
+        await waitForPublished(conversation.$messages) { $0.first?.content == "Hello" }
 
         XCTAssertEqual(conversation.messages.count, 1)
         XCTAssertEqual(conversation.messages.first?.content, "Hello")
         XCTAssertEqual(conversation.messages.first?.role, .agent)
 
         // 2. Delta update
-        let deltaEvent = AgentChatResponsePartEvent(text: " world", type: .delta, eventId: 1)
-        await conversation._testing_handleIncomingEvent(.agentChatResponsePart(deltaEvent))
+        mockWebRTCConnectionManager.deliver(.agentChatResponsePart(
+            AgentChatResponsePartEvent(text: " world", type: .delta, eventId: 1)
+        ))
+        await waitForPublished(conversation.$messages) { $0.first?.content == "Hello world" }
 
         XCTAssertEqual(conversation.messages.count, 1, "Should still have only 1 message, just updated")
         XCTAssertEqual(conversation.messages.first?.content, "Hello world")
 
         // 3. Stop streaming
-        let stopEvent = AgentChatResponsePartEvent(text: "!", type: .stop, eventId: 1)
-        await conversation._testing_handleIncomingEvent(.agentChatResponsePart(stopEvent))
+        mockWebRTCConnectionManager.deliver(.agentChatResponsePart(
+            AgentChatResponsePartEvent(text: "!", type: .stop, eventId: 1)
+        ))
+        await waitForPublished(conversation.$messages) { $0.first?.content == "Hello world!" }
 
         XCTAssertEqual(conversation.messages.count, 1)
         XCTAssertEqual(conversation.messages.first?.content, "Hello world!")
@@ -111,40 +117,32 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
 
     // MARK: - End Call Logic
 
-    func testAutomaticEndCallHandling() async {
-        mockWebRTCConnectionManager.room = Room()
-        conversation._testing_setState(.active(CallInfo(agentId: "test")))
+    func testAutomaticEndCallHandling() async throws {
+        try await conversation.startConversation(auth: .publicAgent(id: "test"))
 
-        let toolResponse = AgentToolResponseEvent(
-            toolName: "end_call",
-            toolCallId: "id",
-            toolType: "action",
-            isError: false,
-            eventId: 1
-        )
+        mockWebRTCConnectionManager.deliver(.agentToolResponse(AgentToolResponseEvent(
+            toolName: "end_call", toolCallId: "id", toolType: "action", isError: false, eventId: 1
+        )))
+        await waitForPublished(conversation.$state) { $0 == .ended(reason: .userEnded) }
 
-        await conversation._testing_handleIncomingEvent(.agentToolResponse(toolResponse))
-
-        // Verify conversation is still active (endConversation guards state.isActive so won't change from idle)
-        XCTAssertEqual(conversation.state, .active(CallInfo(agentId: "test")))
+        XCTAssertEqual(conversation.state, .ended(reason: .userEnded))
     }
 
     // MARK: - Concurrency & Responsiveness
 
     func testStateTransitionsImmediatelyToConnecting() async throws {
-        // Simulate a previously ended conversation
-        conversation._testing_setState(.ended(reason: .userEnded))
+        try await conversation.startConversation(auth: .publicAgent(id: "old-agent"))
+        await conversation.endConversation()
 
-        // Start a new one
+        // Hold agent-ready so we can observe `.connecting` before startup finishes.
+        mockWebRTCConnectionManager.autoSucceedAgentReady = false
         let startTask = Task {
             try await conversation.startConversation(auth: .publicAgent(id: "new-agent"))
         }
 
-        // Check state immediately
-        await Task.yield()
+        await waitForPublished(conversation.$state) { $0 == .connecting }
         XCTAssertEqual(conversation.state, .connecting, "Should be connecting immediately, even if disconnect() is slow")
 
-        // Complete the start
         mockWebRTCConnectionManager.succeedAgentReady()
         try await startTask.value
 
@@ -153,32 +151,27 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
 
     // MARK: - Audio Alignment
 
-    func testAudioAlignmentUpdatesProperty() async {
+    func testAudioAlignmentUpdatesProperty() async throws {
+        try await conversation.startConversation(auth: .publicAgent(id: "test"))
+
         let alignment = AudioAlignment(
             chars: ["H", "e", "l", "l", "o"],
             charStartTimesMs: [0, 100, 200, 300, 400],
             charDurationsMs: [100, 100, 100, 100, 100]
         )
-        let audioEvent = AudioEvent(audioBase64: "base64", eventId: 1, alignment: alignment)
-
-        await conversation._testing_handleIncomingEvent(.audio(audioEvent))
+        mockWebRTCConnectionManager.deliver(.audio(AudioEvent(audioBase64: "base64", eventId: 1, alignment: alignment)))
+        await waitForPublished(conversation.$latestAudioAlignment) { $0 != nil }
 
         XCTAssertEqual(conversation.latestAudioAlignment?.chars, ["H", "e", "l", "l", "o"])
     }
 
-    func testEndConversationClearsLatestAudioState() async {
-        mockWebRTCConnectionManager.room = Room()
-        conversation._testing_setWebRTCConnectionManager(mockWebRTCConnectionManager)
-        conversation._testing_setState(.active(CallInfo(agentId: "test")))
+    func testEndConversationClearsLatestAudioState() async throws {
+        try await conversation.startConversation(auth: .publicAgent(id: "test"))
 
-        let alignment = AudioAlignment(
-            chars: ["H"],
-            charStartTimesMs: [0],
-            charDurationsMs: [100]
-        )
-        let audioEvent = AudioEvent(audioBase64: "base64", eventId: 1, alignment: alignment)
+        let alignment = AudioAlignment(chars: ["H"], charStartTimesMs: [0], charDurationsMs: [100])
+        mockWebRTCConnectionManager.deliver(.audio(AudioEvent(audioBase64: "base64", eventId: 1, alignment: alignment)))
+        await waitForPublished(conversation.$latestAudioAlignment) { $0 != nil }
 
-        await conversation._testing_handleIncomingEvent(.audio(audioEvent))
         XCTAssertNotNil(conversation.latestAudioEvent)
         XCTAssertNotNil(conversation.latestAudioAlignment)
 

--- a/Tests/ElevenLabsTests/Unit/ConversationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationTests.swift
@@ -1,3 +1,5 @@
+import Combine
+
 // swiftlint:disable file_length type_body_length
 @testable import ElevenLabs
 import Foundation
@@ -50,18 +52,12 @@ final class ConversationTests: XCTestCase {
         })
         let conversation = Conversation(dependencyProvider: dependencyProvider, config: config, callbacks: callbacks)
 
-        let startTask = Task {
-            try await conversation.startConversation(
-                auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
-                config: config
-            )
-        }
-
-        await Task.yield()
-        mockWebRTCConnectionManager.succeedAgentReady()
+        try await conversation.startConversation(
+            auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
+            config: config
+        )
 
         await fulfillment(of: [stateExpectation], timeout: 1.0)
-        try await startTask.value
 
         XCTAssertEqual(mockWebRTCConnectionManager.connectCallCount, 1)
         XCTAssertFalse(mockWebRTCConnectionManager.publishedPayloads.isEmpty)
@@ -77,17 +73,10 @@ final class ConversationTests: XCTestCase {
     }
 
     func testStartConversationConfiguresIncomingEventHandler() async throws {
-        let startTask = Task {
-            guard let conversation = self.conversation else { return }
-            try await conversation.startConversation(
-                auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
-                config: makeConfig()
-            )
-        }
-
-        await Task.yield()
-        mockWebRTCConnectionManager.succeedAgentReady()
-        try await startTask.value
+        try await conversation.startConversation(
+            auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
+            config: makeConfig()
+        )
 
         XCTAssertNotNil(mockWebRTCConnectionManager.onEventReceived)
 
@@ -101,13 +90,16 @@ final class ConversationTests: XCTestCase {
         let data = try JSONSerialization.data(withJSONObject: payload)
 
         mockWebRTCConnectionManager.receive(data: data)
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        await waitForPublished(conversation.$messages) { $0.last?.content == "Hello from raw data" }
 
         XCTAssertEqual(conversation.messages.last?.content, "Hello from raw data")
         XCTAssertEqual(conversation.messages.last?.role, .user)
     }
 
     func testStartConversationHandlesIncomingDataBeforeAgentReady() async throws {
+        // Hold agent-ready so we can deliver protocol data while still connecting.
+        mockWebRTCConnectionManager.autoSucceedAgentReady = false
+
         let startTask = Task {
             guard let conversation = self.conversation else { return }
             try await conversation.startConversation(
@@ -116,10 +108,7 @@ final class ConversationTests: XCTestCase {
             )
         }
 
-        await Task.yield()
-        for _ in 0 ..< 10 where mockWebRTCConnectionManager.onEventReceived == nil {
-            try? await Task.sleep(nanoseconds: 10_000_000)
-        }
+        await waitForEventHandlerInstalled(on: mockWebRTCConnectionManager)
 
         guard mockWebRTCConnectionManager.onEventReceived != nil else {
             mockWebRTCConnectionManager.succeedAgentReady()
@@ -138,7 +127,7 @@ final class ConversationTests: XCTestCase {
         let data = try JSONSerialization.data(withJSONObject: payload)
 
         mockWebRTCConnectionManager.receive(data: data)
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        await waitForPublished(conversation.$conversationMetadata) { $0?.conversationId == "conversation-before-ready" }
 
         XCTAssertEqual(conversation.conversationMetadata?.conversationId, "conversation-before-ready")
 
@@ -147,24 +136,18 @@ final class ConversationTests: XCTestCase {
     }
 
     func testStaleProtocolDataHandlerDoesNotMutateEndedConversation() async throws {
-        let startTask = Task {
-            guard let conversation = self.conversation else { return }
-            try await conversation.startConversation(
-                auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
-                config: makeConfig()
-            )
-        }
-
-        await Task.yield()
-        mockWebRTCConnectionManager.succeedAgentReady()
-        try await startTask.value
+        try await conversation.startConversation(
+            auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
+            config: makeConfig()
+        )
 
         let staleHandler = try XCTUnwrap(mockWebRTCConnectionManager.onEventReceived)
 
         await conversation.endConversation()
 
         staleHandler(.agentResponse(AgentResponseEvent(response: "This should be ignored", eventId: 101)))
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        // Drain the MainActor so the handler's spawned Task has run (and been rejected).
+        await Task { @MainActor in }.value
 
         XCTAssertTrue(conversation.messages.isEmpty)
     }
@@ -172,23 +155,16 @@ final class ConversationTests: XCTestCase {
     func testStartConversationConfiguresRoomObservationHandlers() async throws {
         mockWebRTCConnectionManager.isMicrophoneMuted = false
 
-        let startTask = Task {
-            guard let conversation = self.conversation else { return }
-            try await conversation.startConversation(
-                auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
-                config: makeConfig()
-            )
-        }
-
-        await Task.yield()
-        mockWebRTCConnectionManager.succeedAgentReady()
-        try await startTask.value
+        try await conversation.startConversation(
+            auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
+            config: makeConfig()
+        )
 
         XCTAssertNotNil(mockWebRTCConnectionManager.onRemoteSpeakingChanged)
         XCTAssertFalse(conversation.isMuted)
 
         mockWebRTCConnectionManager.onRemoteSpeakingChanged?(true)
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        await waitForPublished(conversation.$agentState) { $0 == .speaking }
 
         XCTAssertEqual(conversation.agentState, .speaking)
     }
@@ -225,19 +201,20 @@ final class ConversationTests: XCTestCase {
         ]
         let data = try JSONSerialization.data(withJSONObject: payload)
         mockWebSocketConnectionManager.receive(data: data)
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        await waitForPublished(conversation.$messages) { $0.last?.content == "Hello over WebSocket" }
 
         XCTAssertEqual(conversation.messages.last?.content, "Hello over WebSocket")
         XCTAssertEqual(conversation.messages.last?.role, .agent)
     }
 
     func testTextOnlyStartDisconnectsPreviousActiveManagerBeforeSwitchingTransports() async throws {
-        mockWebRTCConnectionManager.room = Room()
+        try await conversation.startConversation(auth: .publicAgent(id: "test-agent-id"), config: makeConfig())
+        await conversation.endConversation()
+
+        // Re-arm stale handlers so the transport switch has something to clear.
         mockWebRTCConnectionManager.onEventReceived = { _ in }
         mockWebRTCConnectionManager.onDisconnected = {}
         mockWebRTCConnectionManager.onRemoteSpeakingChanged = { _ in }
-        conversation._testing_setWebRTCConnectionManager(mockWebRTCConnectionManager)
-        conversation._testing_setState(.ended(reason: .userEnded))
 
         let config = makeConfig(configure: { config in
             config.conversationOverrides = ConversationOverrides(textOnly: true)
@@ -248,7 +225,9 @@ final class ConversationTests: XCTestCase {
             config: config
         )
 
-        XCTAssertEqual(mockWebRTCConnectionManager.disconnectCallCount, 1)
+        // 1 (reset-before-connect on the first start) + 1 (real endConversation) + 1 (stale
+        // manager disconnected when the second start switches transport) = 3.
+        XCTAssertEqual(mockWebRTCConnectionManager.disconnectCallCount, 3)
         XCTAssertNil(mockWebRTCConnectionManager.onEventReceived)
         XCTAssertNil(mockWebRTCConnectionManager.onDisconnected)
         XCTAssertNil(mockWebRTCConnectionManager.onRemoteSpeakingChanged)
@@ -342,10 +321,9 @@ final class ConversationTests: XCTestCase {
 
     @MainActor
     func testSetMicrophoneMutedUsesConnectionManagerAudioControl() async throws {
-        mockWebRTCConnectionManager.room = Room()
         mockWebRTCConnectionManager.isMicrophoneMuted = false
-        conversation._testing_setWebRTCConnectionManager(mockWebRTCConnectionManager)
-        conversation._testing_setState(.active(.init(agentId: "test-agent")))
+
+        try await conversation.startConversation(auth: .publicAgent(id: "test-agent"), config: makeConfig())
 
         try await conversation.setMicrophoneMuted(true)
 
@@ -411,7 +389,7 @@ final class ConversationTests: XCTestCase {
         XCTAssertEqual(conversationError, .authenticationFailed("Mock authentication failed"))
         XCTAssertEqual(conversation.state, .idle)
         XCTAssertEqual(conversation.startupMetrics?.tokenFetch, metrics.tokenFetch)
-        let errorsAfterTokenFailure = await capturedErrors.values(waitingFor: 1)
+        let errorsAfterTokenFailure = await waitForValues(capturedErrors, count: 1)
         XCTAssertEqual(errorsAfterTokenFailure, [.authenticationFailed("Mock authentication failed")])
     }
 
@@ -437,13 +415,14 @@ final class ConversationTests: XCTestCase {
         XCTAssertEqual(conversationError, .connectionFailed("Mock connection failed"))
         XCTAssertEqual(conversation.state, .idle)
         XCTAssertEqual(conversation.startupMetrics?.roomConnect, metrics.roomConnect)
-        let errorsAfterConnectionFailure = await capturedErrors.values(waitingFor: 1)
+        let errorsAfterConnectionFailure = await waitForValues(capturedErrors, count: 1)
         XCTAssertEqual(errorsAfterConnectionFailure, [.connectionFailed("Mock connection failed")])
     }
 
     func testStartConversationAgentTimeoutFailure() async {
-        let startupConfig = ConversationStartupConfiguration(agentReadyTimeout: 0.05)
+        mockWebRTCConnectionManager.autoSucceedAgentReady = false
 
+        let startupConfig = ConversationStartupConfiguration(agentReadyTimeout: 0.05)
         let config = makeConfig(startupConfiguration: startupConfig)
 
         let startTask = Task {
@@ -454,7 +433,7 @@ final class ConversationTests: XCTestCase {
             )
         }
 
-        await Task.yield()
+        await waitForEventHandlerInstalled(on: mockWebRTCConnectionManager)
         try? await conversation.setMuted(false)
         XCTAssertFalse(conversation.isMuted)
         mockWebRTCConnectionManager.timeoutAgentReady()
@@ -475,7 +454,7 @@ final class ConversationTests: XCTestCase {
         XCTAssertNil(mockWebRTCConnectionManager.onEventReceived)
         XCTAssertNil(mockWebRTCConnectionManager.onRemoteSpeakingChanged)
         XCTAssertNil(mockWebRTCConnectionManager.errorHandler)
-        let errorsAfterAgentTimeout = await capturedErrors.values(waitingFor: 1)
+        let errorsAfterAgentTimeout = await waitForValues(capturedErrors, count: 1)
         XCTAssertEqual(errorsAfterAgentTimeout, [.agentTimeout])
     }
 
@@ -486,19 +465,11 @@ final class ConversationTests: XCTestCase {
 
         guard let conversation else { return }
 
-        let startTask = Task {
+        await XCTAssertThrowsErrorAsync {
             try await conversation.startConversation(
                 auth: .publicAgent(id: "test-agent"),
                 config: config
             )
-        }
-
-        // Wait for agent ready, THEN publish will fail
-        await Task.yield()
-        mockWebRTCConnectionManager.succeedAgentReady()
-
-        await XCTAssertThrowsErrorAsync {
-            try await startTask.value
         } errorHandler: { error in
             XCTAssertEqual(error as? ConversationError, .connectionFailed("Publish failed"))
         }
@@ -513,17 +484,20 @@ final class ConversationTests: XCTestCase {
         XCTAssertNil(mockWebRTCConnectionManager.onEventReceived)
         XCTAssertNil(mockWebRTCConnectionManager.onRemoteSpeakingChanged)
         XCTAssertNil(mockWebRTCConnectionManager.errorHandler)
-        let errorsAfterInitFailure = await capturedErrors.values(waitingFor: 1)
+        let errorsAfterInitFailure = await waitForValues(capturedErrors, count: 1)
         XCTAssertEqual(errorsAfterInitFailure, [.connectionFailed("Publish failed")])
     }
 
     func testAgentResponseCallbackTogglesFeedbackAvailability() async throws {
-        let receivedResponses = ValueRecorder<(String, Int)>()
+        let gotResponse = expectation(description: "agent response")
+        // Feedback flips more than once (start→false, response→true, feedback→false).
         let feedbackStates = ValueRecorder<Bool>()
 
         let callbacks = makeCallbacks(configure: { callbacks in
             callbacks.onAgentResponse = { text, eventId in
-                Task { await receivedResponses.append((text, eventId)) }
+                XCTAssertEqual(text, "Hello")
+                XCTAssertEqual(eventId, 42)
+                gotResponse.fulfill()
             }
             callbacks.onCanSendFeedbackChange = { canSend in
                 Task { await feedbackStates.append(canSend) }
@@ -532,79 +506,64 @@ final class ConversationTests: XCTestCase {
 
         let conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: callbacks)
 
-        // Set up mock connection manager with a room and active state so sendFeedback can publish
-        mockWebRTCConnectionManager.room = Room()
-        conversation._testing_setWebRTCConnectionManager(mockWebRTCConnectionManager)
-        conversation._testing_setState(ConversationState.active(.init(agentId: "test")))
+        try await conversation.startConversation(auth: .publicAgent(id: "test"), config: makeConfig())
 
-        await conversation._testing_handleIncomingEvent(
-            IncomingEvent.agentResponse(AgentResponseEvent(response: "Hello", eventId: 42))
-        )
+        mockWebRTCConnectionManager.deliver(.agentResponse(AgentResponseEvent(response: "Hello", eventId: 42)))
 
-        // Allow async callbacks to complete
-        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
-
-        let responsesSnapshot = await receivedResponses.values()
-        XCTAssertEqual(responsesSnapshot.count, 1)
-        XCTAssertEqual(responsesSnapshot.first?.0, "Hello")
-        XCTAssertEqual(responsesSnapshot.first?.1, 42)
-        let initialFeedbackState = await feedbackStates.last()
+        await fulfillment(of: [gotResponse], timeout: 1.0)
+        let initialFeedbackState = await waitForLastValue(feedbackStates) { $0 == true }
         XCTAssertEqual(initialFeedbackState, true)
 
         try await conversation.sendFeedback(FeedbackEvent.Score.like, eventId: 42)
 
-        // Allow async callbacks to complete
-        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
-
-        let updatedFeedbackState = await feedbackStates.last()
+        let updatedFeedbackState = await waitForLastValue(feedbackStates) { $0 == false }
         XCTAssertEqual(updatedFeedbackState, false)
     }
 
-    func testVadScoreCallbackReceivesScores() async {
-        let vadScores = ValueRecorder<Double>()
+    func testVadScoreCallbackReceivesScores() async throws {
+        let gotVad = expectation(description: "vad score")
         let callbacks = makeCallbacks(configure: { callbacks in
             callbacks.onVadScore = { score in
-                Task { await vadScores.append(score) }
+                XCTAssertEqual(score, 0.87)
+                gotVad.fulfill()
             }
         })
 
         let conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: callbacks)
-        await conversation._testing_handleIncomingEvent(IncomingEvent.vadScore(VadScoreEvent(vadScore: 0.87)))
+        try await conversation.startConversation(auth: .publicAgent(id: "test"), config: makeConfig())
 
-        // Allow async callbacks to complete
-        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        mockWebRTCConnectionManager.deliver(.vadScore(VadScoreEvent(vadScore: 0.87)))
 
-        let vadSnapshot = await vadScores.values()
-        XCTAssertEqual(vadSnapshot, [0.87])
+        await fulfillment(of: [gotVad], timeout: 1.0)
     }
 
-    func testAgentToolResponseCallbackReceivesEvent() async {
-        let capturedToolNames = ValueRecorder<String>()
+    func testAgentToolResponseCallbackReceivesEvent() async throws {
+        let gotTool = expectation(description: "agent tool response")
         let callbacks = makeCallbacks(configure: { callbacks in
-            callbacks.onAgentToolResponse = { (event: AgentToolResponseEvent) in
-                Task { await capturedToolNames.append(event.toolName) }
+            callbacks.onAgentToolResponse = { event in
+                XCTAssertEqual(event.toolName, "lookup_weather")
+                gotTool.fulfill()
             }
         })
 
         let conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: callbacks)
-        let toolEvent = AgentToolResponseEvent(toolName: "end_call", toolCallId: "id", toolType: "action", isError: false, eventId: 10)
+        try await conversation.startConversation(auth: .publicAgent(id: "test"), config: makeConfig())
 
-        await conversation._testing_handleIncomingEvent(IncomingEvent.agentToolResponse(toolEvent))
+        mockWebRTCConnectionManager.deliver(.agentToolResponse(AgentToolResponseEvent(
+            toolName: "lookup_weather", toolCallId: "id", toolType: "action", isError: false, eventId: 10
+        )))
 
-        // Allow async callbacks to complete
-        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
-
-        let toolNames = await capturedToolNames.values()
-        XCTAssertEqual(toolNames, ["end_call"])
+        await fulfillment(of: [gotTool], timeout: 1.0)
     }
 
-    func testInterruptionCallbackDisablesFeedback() async {
-        let interruptionIds = ValueRecorder<Int>()
+    func testInterruptionCallbackDisablesFeedback() async throws {
+        let gotInterruption = expectation(description: "interruption")
         let feedbackStates = ValueRecorder<Bool>()
 
         let callbacks = makeCallbacks(configure: { callbacks in
             callbacks.onInterruption = { id in
-                Task { await interruptionIds.append(id) }
+                XCTAssertEqual(id, 7)
+                gotInterruption.fulfill()
             }
             callbacks.onCanSendFeedbackChange = { canSend in
                 Task { await feedbackStates.append(canSend) }
@@ -612,14 +571,12 @@ final class ConversationTests: XCTestCase {
         })
 
         let conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: callbacks)
-        await conversation._testing_handleIncomingEvent(IncomingEvent.interruption(InterruptionEvent(eventId: 7)))
+        try await conversation.startConversation(auth: .publicAgent(id: "test"), config: makeConfig())
 
-        // Allow async callbacks to complete
-        try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        mockWebRTCConnectionManager.deliver(.interruption(InterruptionEvent(eventId: 7)))
 
-        let interruptionSnapshot = await interruptionIds.values()
-        XCTAssertEqual(interruptionSnapshot, [7])
-        let interruptionFeedbackState = await feedbackStates.last()
+        await fulfillment(of: [gotInterruption], timeout: 1.0)
+        let interruptionFeedbackState = await waitForLastValue(feedbackStates) { $0 == false }
         XCTAssertEqual(interruptionFeedbackState, false)
     }
 
@@ -670,100 +627,36 @@ final class ConversationTests: XCTestCase {
     }
 
     func testAgentDisconnectEndsConversation() async throws {
-        let disconnectReasons = ValueRecorder<DisconnectionReason>()
+        let gotDisconnect = expectation(description: "agent disconnect")
         let config = makeConfig()
         let callbacks = makeCallbacks(configure: { callbacks in
             callbacks.onDisconnect = { reason in
-                Task { await disconnectReasons.append(reason) }
+                XCTAssertEqual(reason, .agent)
+                gotDisconnect.fulfill()
             }
         })
         let conversation = Conversation(dependencyProvider: dependencyProvider, config: config, callbacks: callbacks)
 
-        let startTask = Task {
-            try await conversation.startConversation(
-                auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
-                config: config
-            )
-        }
-        await Task.yield()
-        mockWebRTCConnectionManager.succeedAgentReady()
-        try await startTask.value
+        try await conversation.startConversation(
+            auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
+            config: config
+        )
         XCTAssertEqual(conversation.state, .active(.init(agentId: "test-agent-id")))
-        // capture call counts before the disconnect event.
         let disconnectsBefore = mockWebRTCConnectionManager.disconnectCallCount
-        // Simulate agent disconnect
+
         await mockWebRTCConnectionManager.onDisconnected?()
-        // assert disconnect was handled with correct reasons
+
         XCTAssertEqual(
             mockWebRTCConnectionManager.disconnectCallCount,
             disconnectsBefore + 1,
             "Agent disconnect should trigger webRTCConnectionManager.disconnect()"
         )
-        let reasons = await disconnectReasons.values(waitingFor: 1)
-        XCTAssertEqual(reasons, [.agent])
+        await fulfillment(of: [gotDisconnect], timeout: 1.0)
         XCTAssertEqual(conversation.state, .ended(reason: .remoteDisconnected))
     }
 }
 
 // swiftlint:enable file_length type_body_length
-
-@MainActor
-extension XCTestCase {
-    fileprivate func XCTAssertThrowsErrorAsync(
-        _ expression: () async throws -> some Sendable,
-        _ message: @autoclosure () -> String = "",
-        file: StaticString = #filePath,
-        line: UInt = #line,
-        errorHandler: (Error) -> Void = { _ in }
-    ) async {
-        do {
-            _ = try await expression()
-            XCTFail(message(), file: file, line: line)
-        } catch {
-            errorHandler(error)
-        }
-    }
-}
-
-actor ValueRecorder<Value> {
-    private var storage: [Value] = []
-
-    func append(_ value: Value) {
-        storage.append(value)
-    }
-
-    func reset() {
-        storage.removeAll()
-    }
-
-    func values() -> [Value] {
-        storage
-    }
-
-    func values(waitingFor expectedCount: Int, timeout: TimeInterval = 1.0) async -> [Value] {
-        guard expectedCount > 0 else {
-            return storage
-        }
-
-        let deadline = Date().addingTimeInterval(timeout)
-
-        while storage.count < expectedCount, Date() < deadline {
-            let remaining = max(deadline.timeIntervalSinceNow, 0)
-            let sleepInterval = remaining > 0 ? min(remaining, 0.01) : 0
-            if sleepInterval <= 0 {
-                break
-            }
-            let nanos = UInt64(sleepInterval * 1_000_000_000)
-            try? await Task.sleep(nanoseconds: max(nanos, 1_000_000)) // minimum 1ms
-        }
-
-        return storage
-    }
-
-    func last() -> Value? {
-        storage.last
-    }
-}
 
 extension ConversationTests {
     private func makeConfig(

--- a/Tests/ElevenLabsTests/Unit/LiveKitRoomEventDelegateTests.swift
+++ b/Tests/ElevenLabsTests/Unit/LiveKitRoomEventDelegateTests.swift
@@ -17,43 +17,46 @@ final class LiveKitRoomEventDelegateTests: XCTestCase {
     }
 
     func testForwardsReceivedData() async {
-        let received = ValueRecorder<Data>()
-        let delegate = makeDelegate(onData: { value in Task { await received.append(value) } })
+        let got = expectation(description: "data")
         let payload = Data([0x01, 0x02, 0x03])
+        let delegate = makeDelegate(onData: {
+            XCTAssertEqual($0, payload)
+            got.fulfill()
+        })
 
         delegate.room?(Room(), participant: nil, didReceiveData: payload, forTopic: "topic", encryptionType: .none)
 
-        let values = await received.values(waitingFor: 1)
-        XCTAssertEqual(values, [payload])
+        await fulfillment(of: [got], timeout: 1.0)
     }
 
     func testForwardsSpeaking() async {
-        let speaking = ValueRecorder<Bool>()
-        let delegate = makeDelegate(onRemoteSpeaking: { value in Task { await speaking.append(value) } })
+        let got = expectation(description: "speaking")
+        let delegate = makeDelegate(onRemoteSpeaking: {
+            XCTAssertEqual($0, false, "No remote speakers must forward not-speaking.")
+            got.fulfill()
+        })
 
         delegate.room?(Room(), didUpdateSpeakingParticipants: [])
 
-        let values = await speaking.values(waitingFor: 1)
-        XCTAssertEqual(values, [false], "No remote speakers must forward not-speaking.")
+        await fulfillment(of: [got], timeout: 1.0)
     }
 
     func testForwardsDisconnectOnConnectionLoss() async {
-        let disconnects = ValueRecorder<Bool>()
-        let delegate = makeDelegate(onRemoteDisconnect: { await disconnects.append(true) })
+        let got = expectation(description: "disconnect")
+        let delegate = makeDelegate(onRemoteDisconnect: { got.fulfill() })
 
         delegate.room?(Room(), didUpdateConnectionState: .disconnected, from: .connected)
 
-        let values = await disconnects.values(waitingFor: 1)
-        XCTAssertEqual(values, [true])
+        await fulfillment(of: [got], timeout: 1.0)
     }
 
     func testIgnoresNonDisconnectedConnectionState() async {
-        let disconnects = ValueRecorder<Bool>()
-        let delegate = makeDelegate(onRemoteDisconnect: { await disconnects.append(true) })
+        nonisolated(unsafe) var called = false
+        let delegate = makeDelegate(onRemoteDisconnect: { called = true })
 
         delegate.room?(Room(), didUpdateConnectionState: .connected, from: .connecting)
+        await Task { @MainActor in }.value
 
-        let values = await disconnects.values(waitingFor: 1, timeout: 0.2)
-        XCTAssertTrue(values.isEmpty, "Only a disconnected state should signal disconnect.")
+        XCTAssertFalse(called)
     }
 }


### PR DESCRIPTION
## Summary
- Remove `_testing_*` backdoors from `Conversation`; drive tests through real `startConversation` + mock handshake (`autoSucceedAgentReady` / `deliver` / `receive`)
- Replace `Task.sleep` / polling with event-driven waits (`waitForPublished`, expectations, `ValueRecorder`) — shared in `TestSupport.swift`
- Fix `testAutomaticEndCallHandling` - it was testing for incorrect behavior
- Suite ~30% faster locally (~4.4s → ~3.0s mean over 5 warm runs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production change is limited to deleting test-only APIs on `Conversation`; remaining edits are test infrastructure and assertions with no runtime behavior change.
> 
> **Overview**
> Removes **`Conversation`** `_testing_*` backdoors and refactors unit tests to exercise the real **`startConversation`** path with **`MockWebRTCConnectionManager`** helpers (`autoSucceedAgentReady`, **`deliver`**, **`receive`**, **`waitForEventHandlerInstalled`**).
> 
> Adds shared **`TestSupport.swift`** with event-driven waits (`waitForPublished`, **`ValueRecorder`** continuations, **`waitForValues`**) and replaces **`Task.sleep`** / polling across **`ConversationTests`**, **`BusinessLogicTests`**, and **`LiveKitRoomEventDelegateTests`**. **`testAutomaticEndCallHandling`** now asserts an **`end_call`** agent tool response ends the session (**.ended**), correcting the prior expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea7bdb1a6363fdf12ce952955ccd8cf27f81c97a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->