### PR TITLE
chore: clean up Conversation leftovers after ConversationClient

### DIFF
--- a/Sources/ElevenLabs/Internal/Conversation/ConnectionManaging.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/ConnectionManaging.swift
@@ -1,5 +1,4 @@
 import Foundation
-import LiveKit
 
 enum ConnectionManagerError: Error {
     case notConnected
@@ -20,8 +19,6 @@ protocol WebSocketConnectionManaging: ConnectionManaging {
 
 protocol WebRTCConnectionManaging: ConnectionManaging {
     var onRemoteSpeakingChanged: (@Sendable (Bool) -> Void)? { get set }
-    var inputTrack: LocalAudioTrack? { get }
-    var agentAudioTrack: RemoteAudioTrack? { get }
     var isMicrophoneMuted: Bool { get }
 
     @MainActor

--- a/Sources/ElevenLabs/Internal/Conversation/Conversation+Events.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/Conversation+Events.swift
@@ -53,7 +53,6 @@ extension Conversation {
             callbacks.onCanSendFeedbackChange?(false)
 
         case let .conversationMetadata(metadata):
-            // Store the conversation metadata for public access
             conversationMetadata = metadata
             callbacks.onConversationMetadata?(metadata)
 

--- a/Sources/ElevenLabs/Internal/Conversation/ConversationAudioManager.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/ConversationAudioManager.swift
@@ -8,8 +8,6 @@ import LiveKit
 /// Encapsulates all AudioManager interactions to keep Conversation class focused on conversation logic.
 @MainActor
 final class ConversationAudioManager {
-    private(set) var audioDevices: [AudioDevice] = []
-    private(set) var selectedAudioDeviceID: String = ""
     private(set) var softwareMuteProcessor: SoftwareMuteProcessor?
 
     private let audioManager = AudioManager.shared
@@ -17,22 +15,13 @@ final class ConversationAudioManager {
     private var audioSpeechHandlerInstalled = false
     private let logger: any Logging
 
-    /// Callback when audio devices list changes
-    var onDevicesChanged: (([AudioDevice]) -> Void)?
-
-    /// Callback when selected device changes
-    var onSelectedDeviceChanged: ((String) -> Void)?
-
     init(logger: any Logging) {
         self.logger = logger
-        audioDevices = audioManager.inputDevices
-        selectedAudioDeviceID = audioManager.inputDevice.deviceId
         setupInitialConfiguration()
     }
 
     deinit {
         // Reset callbacks directly since we can't call MainActor methods from deinit
-        audioManager.onDeviceUpdate = nil
         if audioSpeechHandlerInstalled {
             audioManager.onMutedSpeechActivity = previousSpeechActivityHandler
         }
@@ -81,31 +70,18 @@ final class ConversationAudioManager {
     // MARK: - Private
 
     private func setupInitialConfiguration() {
-        // Set initial microphone mute mode
         do {
             try audioManager.set(microphoneMuteMode: .inputMixer)
         } catch {
             logger.warning("Failed to set initial microphone mute mode", context: ["error": "\(error)"])
         }
 
-        // Set recording always prepared mode asynchronously
         Task { [weak self] in
             guard let self else { return }
             do {
                 try await audioManager.setRecordingAlwaysPreparedMode(true)
             } catch {
                 logger.warning("Failed to set recording always prepared mode", context: ["error": "\(error)"])
-            }
-        }
-
-        // Setup device change observer
-        audioManager.onDeviceUpdate = { [weak self] _ in
-            Task { @MainActor in
-                guard let self else { return }
-                self.audioDevices = self.audioManager.inputDevices
-                self.selectedAudioDeviceID = self.audioManager.defaultInputDevice.deviceId
-                self.onDevicesChanged?(self.audioDevices)
-                self.onSelectedDeviceChanged?(self.selectedAudioDeviceID)
             }
         }
     }

--- a/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
@@ -20,11 +20,6 @@ enum WebRTCConnectionManagerError: Error {
 /// LiveKit observation is split across two `RoomDelegate` instances:
 /// - `LiveKitRoomEventDelegate` — data, speaking, remote disconnect
 /// - `LiveKitReadinessDelegate` — signals when the agent's audio track subscribes
-///
-/// Note: `Room`, `LocalAudioTrack`, and `RemoteAudioTrack` are intentionally
-/// exposed on the public SDK surface (e.g. `Conversation.inputTrack`), so this
-/// type does not fully hide LiveKit from callers. It does centralize the
-/// dependency in one place.
 final class WebRTCConnectionManager: WebRTCConnectionManaging {
     /// Fired when the remote agent leaves, the room disconnects, or all remote participants are gone.
     var onDisconnected: (() async -> Void)?
@@ -37,17 +32,9 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
 
     var errorHandler: ((Swift.Error?) -> Void)?
 
-    // MARK: – Public state accessors
+    // MARK: – State
 
     private(set) var room: Room?
-
-    var inputTrack: LocalAudioTrack? {
-        room?.localParticipant.firstAudioPublication?.track as? LocalAudioTrack
-    }
-
-    var agentAudioTrack: RemoteAudioTrack? {
-        room?.remoteParticipants.values.first?.firstAudioPublication?.track as? RemoteAudioTrack
-    }
 
     var isMicrophoneMuted: Bool {
         guard let room else { return true }

--- a/Sources/ElevenLabs/Public/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Conversation.swift
@@ -1,14 +1,12 @@
 import Combine
 import Foundation
-import LiveKit
 
 // swiftlint:disable file_length type_body_length
 
 /// A single-use conversation session, created by and owned by `ConversationClient`.
 ///
-/// Manages the lifecycle of one conversation: network layer
-/// (`WebRTCConnectionManager`|`WebSocketConnectionManager`), protocol parser
-/// (`EventParser`), and audio device setup.
+/// Coordinates the network layer (`WebRTCConnectionManager`|`WebSocketConnectionManager`),
+/// protocol parser (`EventParser`), and audio device setup for one conversation.
 @MainActor
 final class Conversation: ObservableObject {
     // MARK: - State
@@ -38,21 +36,14 @@ final class Conversation: ObservableObject {
     /// Latest audio event emitted by the agent.
     @Published var latestAudioEvent: AudioEvent?
 
-    /// Device lists (optional to expose; keep `internal` if you don't want them public)
-    @Published var audioDevices: [AudioDevice] = []
-    @Published var selectedAudioDeviceID: String = ""
-
     var lastAgentEventId: Int?
     var lastFeedbackSubmittedEventId: Int?
 
     /// Pending mute state to apply after connection completes.
-    /// Allows setting mute state during connection phase.
     private var pendingMuteState: Bool?
 
-    /// Audio device management
     private var audioManager: ConversationAudioManager?
 
-    /// Agent state manager for event-based state tracking
     var agentStateManager: AgentStateManager?
 
     /// Forward a signal to the event-based state manager, or fall back to directly setting `agentState`.
@@ -64,7 +55,7 @@ final class Conversation: ObservableObject {
         }
     }
 
-    func handleRemoteSpeakingUpdate(isSpeaking: Bool) {
+    private func handleRemoteSpeakingUpdate(isSpeaking: Bool) {
         if let manager = agentStateManager {
             manager.processSignal(isSpeaking ? .agentStartedSpeaking : .agentStoppedSpeaking)
         } else if isSpeaking {
@@ -80,15 +71,6 @@ final class Conversation: ObservableObject {
 
     /// Context for logging (e.g. agentId)
     private var activeContext: [String: String]?
-
-    /// Audio tracks for advanced use cases
-    var inputTrack: LocalAudioTrack? {
-        activeWebRTCConnectionManager?.inputTrack
-    }
-
-    var agentAudioTrack: RemoteAudioTrack? {
-        activeWebRTCConnectionManager?.agentAudioTrack
-    }
 
     // MARK: - Init
 
@@ -106,17 +88,7 @@ final class Conversation: ObservableObject {
 
     private func setupAudioManager() {
         guard !config.conversationOverrides.textOnly else { return }
-        let manager = ConversationAudioManager(logger: logger)
-        manager.onDevicesChanged = { [weak self] devices in
-            self?.audioDevices = devices
-        }
-        manager.onSelectedDeviceChanged = { [weak self] deviceId in
-            self?.selectedAudioDeviceID = deviceId
-        }
-        audioManager = manager
-        // Sync initial values
-        audioDevices = manager.audioDevices
-        selectedAudioDeviceID = manager.selectedAudioDeviceID
+        audioManager = ConversationAudioManager(logger: logger)
     }
 
     private func setupAgentStateManager() {
@@ -131,21 +103,13 @@ final class Conversation: ObservableObject {
 
     // MARK: - API
 
-    /// Start a conversation with an agent using agent ID.
-    func startConversation(
-        with agentId: String,
-        config: ConversationConfig = .init()
-    ) async throws {
-        let authConfig = ConversationCredentials.publicAgent(id: agentId, environment: config.environment)
-        try await startConversation(auth: authConfig, config: config)
-    }
-
-    /// Start a conversation using authentication configuration.
+    /// Start this single-use session. Only valid from `.idle` (including after a failed start).
+    /// Once the session has `.ended`, create a new `Conversation` via `ConversationClient`.
     func startConversation(
         auth: ConversationCredentials,
         config: ConversationConfig = .init()
     ) async throws {
-        guard state == .idle || state.isEnded else {
+        guard state == .idle else {
             throw ConversationError.alreadyActive
         }
 
@@ -178,9 +142,6 @@ final class Conversation: ObservableObject {
             }
         }
 
-        if audioManager == nil {
-            setupAudioManager()
-        }
         await audioManager?.configure(with: config)
 
         let result: StartupResult
@@ -238,31 +199,24 @@ final class Conversation: ObservableObject {
         }
     }
 
-    /// End and clean up.
-    /// Can be called during connection phase to cancel, or during active conversation to end.
-    func endConversation() async {
-        await endConversation(disconnectReason: .user, endReason: .userEnded)
-    }
-
-    private func endConversation(disconnectReason: DisconnectionReason = .user, endReason: EndReason = .userEnded) async {
-        // Allow ending during both active and connecting states
+    /// End and clean up. Callable during connect (cancel) or while active.
+    func endConversation(
+        disconnectReason: DisconnectionReason = .user,
+        endReason: EndReason = .userEnded
+    ) async {
         guard state.isActive || state == .connecting else { return }
         guard let connectionManager = activeConnectionManager else {
-            // No connection manager yet, just reset state
             if state == .connecting {
                 state = .idle
-                tearDownActiveSession()
+                tearDown()
             }
             return
         }
         state = .ended(reason: endReason)
 
-        // Disconnect synchronously to ensure clean state
         await connectionManager.disconnect()
+        tearDown()
 
-        tearDownActiveSession()
-
-        // Call user's onDisconnect callback if provided
         callbacks.onDisconnect?(disconnectReason)
         callbacks.onCanSendFeedbackChange?(false)
     }
@@ -397,7 +351,7 @@ final class Conversation: ObservableObject {
         activeConnectionManager as? any WebRTCConnectionManaging
     }
 
-    var config: ConversationConfig
+    private var config: ConversationConfig
     let callbacks: ConversationCallbacks
 
     var speakingTimer: Task<Void, Never>?
@@ -407,23 +361,17 @@ final class Conversation: ObservableObject {
         callbacks.onStartupStateChange?(newState)
     }
 
-    /// Common preparation shared by voice and text-only startup paths.
+    /// Wire handlers and move to `.connecting`. Dependency providers may reuse
+    /// manager instances across sessions, so disconnect first to clear stale state.
     private func prepareConversationStart(
         auth: ConversationCredentials,
         config: ConversationConfig,
         connectionManager: any ConnectionManaging
     ) async {
-        let previousConnectionManager = activeConnectionManager
         state = .connecting
-
-        if let previousConnectionManager, previousConnectionManager !== connectionManager {
-            await previousConnectionManager.disconnect()
-        }
-
         activeConnectionManager = connectionManager
-        // Reset the target manager too; dependency providers may reuse manager instances across starts.
+        // Providers may reuse manager instances across sessions; clear stale handlers first.
         await connectionManager.disconnect()
-        cleanupPreviousConversation()
         self.config = config
 
         activeContext = ["agentId": auth.agentId]
@@ -433,16 +381,9 @@ final class Conversation: ObservableObject {
         callbacks.onCanSendFeedbackChange?(false)
         setupAgentStateManager()
 
-        connectionManager.onEventReceived = { [weak self, weak connectionManager] event in
-            Task { @MainActor [weak self, weak connectionManager] in
-                guard let self,
-                      let connectionManager,
-                      activeConnectionManager === connectionManager,
-                      state == .connecting || state.isActive
-                else {
-                    return
-                }
-
+        connectionManager.onEventReceived = { [weak self] event in
+            Task { @MainActor [weak self] in
+                guard let self, state == .connecting || state.isActive else { return }
                 await handleIncomingEvent(event)
             }
         }
@@ -457,7 +398,7 @@ final class Conversation: ObservableObject {
         disconnecting connectionManager: any ConnectionManaging,
         suggestLocalNetworkPermission: Bool
     ) async {
-        cleanupTransientResources()
+        tearDown()
         await connectionManager.disconnect()
 
         startupMetrics = failure.metrics
@@ -474,46 +415,17 @@ final class Conversation: ObservableObject {
     }
 
     private func handleStartupCancellation(disconnecting connectionManager: any ConnectionManaging) async {
-        cleanupTransientResources()
+        tearDown()
         await connectionManager.disconnect()
         startupMetrics = nil
         state = .idle
         updateStartupState(.idle)
     }
 
-    /// Clean up state from any previous conversation to ensure a fresh start.
-    /// Called when starting a new session; wipes both operational and display state.
-    private func cleanupPreviousConversation() {
-        tearDownActiveSession()
-
-        messages.removeAll()
-        mcpToolCalls.removeAll()
-        mcpConnectionStatus = nil
-        conversationMetadata = nil
-
-        startupState = .idle
-        startupMetrics = nil
-
-        logger.debug("Previous conversation state cleaned up for fresh Room", context: activeContext)
-    }
-
-    /// Tear down operational state when an active session ends.
-    /// Preserves user-visible display state (messages, MCP activity, conversation
-    /// metadata, startup metrics) so the transcript remains visible until a new
-    /// conversation is started.
-    private func tearDownActiveSession() {
-        cleanupTransientResources()
-
-        pendingToolCalls.removeAll()
-
-        lastAgentEventId = nil
-        lastFeedbackSubmittedEventId = nil
-        callbacks.onCanSendFeedbackChange?(false)
-        latestAudioEvent = nil
-        latestAudioAlignment = nil
-    }
-
-    private func cleanupTransientResources() {
+    /// Release operational resources when the session ends or fails.
+    /// On a clean end, display state (messages, MCP, metadata, startup metrics) is kept
+    /// so the client can still show the transcript.
+    private func tearDown() {
         speakingTimer?.cancel()
         speakingTimer = nil
         pendingMuteState = nil
@@ -522,6 +434,13 @@ final class Conversation: ObservableObject {
 
         audioManager?.cleanup()
         agentStateManager = nil
+
+        pendingToolCalls.removeAll()
+        lastAgentEventId = nil
+        lastFeedbackSubmittedEventId = nil
+        callbacks.onCanSendFeedbackChange?(false)
+        latestAudioEvent = nil
+        latestAudioAlignment = nil
     }
 
     private func scheduleBackToListening(delay: TimeInterval = 0.5) {

--- a/Sources/ElevenLabs/Public/Conversation/ConversationError.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationError.swift
@@ -8,7 +8,6 @@ public enum ConversationError: LocalizedError, Sendable, Equatable {
     case agentTimeout
     case microphoneToggleFailed(String) // Store error description instead of Error for Equatable
     case localNetworkPermissionRequired
-    case noSoftwareMuteHandlerConfigured
     case serverError(ErrorEvent)
 
     /// Helper methods to create errors with Error types
@@ -30,7 +29,6 @@ public enum ConversationError: LocalizedError, Sendable, Equatable {
         case let .microphoneToggleFailed(description): "Failed to toggle microphone: \(description)"
         case .localNetworkPermissionRequired: "Local Network permission is required."
         case let .serverError(event): "Server error (\(event.code)): \(event.message ?? "unknown")"
-        case .noSoftwareMuteHandlerConfigured: "No software mute handler is configured."
         }
     }
 }

--- a/Sources/ElevenLabs/Public/Conversation/ConversationState.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationState.swift
@@ -5,20 +5,9 @@ public enum ConversationState: Equatable, Sendable {
     case connecting
     case active(CallInfo)
     case ended(reason: EndReason)
-    case error(ConversationError)
 
     public var isActive: Bool {
         if case .active = self { return true }
         return false
-    }
-
-    var isEnded: Bool {
-        if case .ended = self { return true }
-        return false
-    }
-
-    var activeAgentId: String? {
-        if case let .active(info) = self { return info.agentId }
-        return nil
     }
 }

--- a/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
+++ b/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
@@ -24,8 +24,6 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
 
     var room: Room?
 
-    var inputTrack: LocalAudioTrack?
-    var agentAudioTrack: RemoteAudioTrack?
     var isMicrophoneMuted = true
 
     var errorHandler: ((Swift.Error?) -> Void)?

--- a/Tests/ElevenLabsTests/StartupPerformanceTest.swift
+++ b/Tests/ElevenLabsTests/StartupPerformanceTest.swift
@@ -72,8 +72,6 @@ final class StartupPerformanceTest: XCTestCase {
             print("  🎯 ACTIVE STATE REACHED in \(String(format: "%.3f", elapsed))s")
         case let .ended(reason):
             print("  [\(String(format: "%.3f", elapsed))s] State: ended (reason: \(reason))")
-        case let .error(error):
-            print("  [\(String(format: "%.3f", elapsed))s] State: error - \(error)")
         }
 
         // Check for existing messages

--- a/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
+++ b/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
@@ -128,27 +128,6 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
         XCTAssertEqual(conversation.state, .ended(reason: .userEnded))
     }
 
-    // MARK: - Concurrency & Responsiveness
-
-    func testStateTransitionsImmediatelyToConnecting() async throws {
-        try await conversation.startConversation(auth: .publicAgent(id: "old-agent"))
-        await conversation.endConversation()
-
-        // Hold agent-ready so we can observe `.connecting` before startup finishes.
-        mockWebRTCConnectionManager.autoSucceedAgentReady = false
-        let startTask = Task {
-            try await conversation.startConversation(auth: .publicAgent(id: "new-agent"))
-        }
-
-        await waitForPublished(conversation.$state) { $0 == .connecting }
-        XCTAssertEqual(conversation.state, .connecting, "Should be connecting immediately, even if disconnect() is slow")
-
-        mockWebRTCConnectionManager.succeedAgentReady()
-        try await startTask.value
-
-        XCTAssertEqual(conversation.state, .active(CallInfo(agentId: "new-agent")))
-    }
-
     // MARK: - Audio Alignment
 
     func testAudioAlignmentUpdatesProperty() async throws {

--- a/Tests/ElevenLabsTests/Unit/ConversationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationTests.swift
@@ -207,32 +207,16 @@ final class ConversationTests: XCTestCase {
         XCTAssertEqual(conversation.messages.last?.role, .agent)
     }
 
-    func testTextOnlyStartDisconnectsPreviousActiveManagerBeforeSwitchingTransports() async throws {
+    func testStartAfterEndedThrowsAlreadyActive() async throws {
         try await conversation.startConversation(auth: .publicAgent(id: "test-agent-id"), config: makeConfig())
         await conversation.endConversation()
+        XCTAssertEqual(conversation.state, .ended(reason: .userEnded))
 
-        // Re-arm stale handlers so the transport switch has something to clear.
-        mockWebRTCConnectionManager.onEventReceived = { _ in }
-        mockWebRTCConnectionManager.onDisconnected = {}
-        mockWebRTCConnectionManager.onRemoteSpeakingChanged = { _ in }
-
-        let config = makeConfig(configure: { config in
-            config.conversationOverrides = ConversationOverrides(textOnly: true)
-        })
-
-        try await conversation.startConversation(
-            auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
-            config: config
-        )
-
-        // 1 (reset-before-connect on the first start) + 1 (real endConversation) + 1 (stale
-        // manager disconnected when the second start switches transport) = 3.
-        XCTAssertEqual(mockWebRTCConnectionManager.disconnectCallCount, 3)
-        XCTAssertNil(mockWebRTCConnectionManager.onEventReceived)
-        XCTAssertNil(mockWebRTCConnectionManager.onDisconnected)
-        XCTAssertNil(mockWebRTCConnectionManager.onRemoteSpeakingChanged)
-        XCTAssertEqual(mockWebSocketConnectionManager.connectCallCount, 1)
-        XCTAssertEqual(conversation.state, .active(.init(agentId: "test-agent-id")))
+        await XCTAssertThrowsErrorAsync {
+            try await conversation.startConversation(auth: .publicAgent(id: "test-agent-id"), config: makeConfig())
+        } errorHandler: { error in
+            XCTAssertEqual(error as? ConversationError, .alreadyActive)
+        }
     }
 
     func testStartTextOnlySignedURLUsesProvidedWebSocketURL() async throws {


### PR DESCRIPTION
## Summary
- Drop dead audio device/track passthrough, unused `ConversationError`/`ConversationState` cases, and same-instance restart helpers left over after `ConversationClient`.
- Update related unit tests for the single-use session model.

Stacked on #205 (`conversation-client`).

## Test plan
- [ ] `swift build --build-tests`
- [ ] `ConversationClientTests`, `ConversationTests`, `ElevenLabsBusinessLogicTests`
