### PR TITLE
refactor: rename conversation active state to connected

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -64,7 +64,7 @@ conversation.$agentState
 
 ### Connection State
 
-Handle transitions between idle, connecting, active, and ended states.
+Handle transitions between idle, connecting, connected, and ended states.
 
 ```swift
 conversation.$state
@@ -74,7 +74,7 @@ conversation.$state
             break
         case .connecting:
             break
-        case .active(let callInfo):
+        case .connected(let callInfo):
             print("Connected to agent: \(callInfo.agentId)")
         case .ended(let reason):
             print("Conversation ended: \(reason)")
@@ -605,7 +605,7 @@ class ReconnectionManager: ObservableObject {
                         self.showReconnectButton = true
                         self.reconnectAttempts = 0
                     }
-                case .active:
+                case .connected:
                     self.showReconnectButton = false
                     self.isReconnecting = false
                     self.reconnectAttempts = 0
@@ -733,8 +733,8 @@ Always call SDK methods from the `@MainActor` when interacting with the UI. The 
 Although the SDK uses ARC, we recommend calling `endConversation()` when the user leaves the chat screen to promptly release WebRTC resources.
 
 ```swift
-// Call endConversation() when the conversation is active
-if conversation.state.isActive {
+// Call endConversation() when the conversation is connected
+if conversation.state.isConnected {
     await conversation.endConversation()
 }
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ struct ChatView: View {
                     switch conversation.state {
                     case .idle: Text("Status: idle")
                     case .connecting: Text("Status: connecting")
-                    case .active(let info): Text("Connected to: \(info.agentId)")
+                    case .connected(let info): Text("Connected to: \(info.agentId)")
                     case .ended: Text("Status: ended")
                     case .error: Text("Status: error")
                     }

--- a/Sources/ElevenLabs/Public/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Conversation.swift
@@ -167,9 +167,9 @@ public final class Conversation: ObservableObject {
             try await startVoiceConversation(auth: auth, config: config, provider: dependencyProvider)
         }
 
-        state = .active(.init(agentId: result.agentId))
+        state = .connected(.init(agentId: result.agentId))
         startupMetrics = result.metrics
-        updateStartupState(.active(CallInfo(agentId: result.agentId), result.metrics))
+        updateStartupState(.connected(CallInfo(agentId: result.agentId), result.metrics))
         callbacks.onAgentReady?()
     }
 
@@ -251,14 +251,14 @@ public final class Conversation: ObservableObject {
     }
 
     /// End and clean up.
-    /// Can be called during connection phase to cancel, or during active conversation to end.
+    /// Can be called during connection phase to cancel, or during connected conversation to end.
     public func endConversation() async {
         await endConversation(disconnectReason: .user, endReason: .userEnded)
     }
 
     private func endConversation(disconnectReason: DisconnectionReason = .user, endReason: EndReason = .userEnded) async {
-        // Allow ending during both active and connecting states
-        guard state.isActive || state == .connecting else { return }
+        // Allow ending during both connected and connecting states
+        guard state.isConnected || state == .connecting else { return }
         guard let connectionManager = activeConnectionManager else {
             // No connection manager yet, just reset state
             if state == .connecting {
@@ -281,7 +281,7 @@ public final class Conversation: ObservableObject {
 
     /// Send a text message to the agent.
     public func sendMessage(_ text: String) async throws {
-        guard state.isActive else {
+        guard state.isConnected else {
             throw ConversationError.notConnected
         }
         let event = OutgoingEvent.userMessage(UserMessageEvent(text: text))
@@ -305,7 +305,7 @@ public final class Conversation: ObservableObject {
     }
 
     func setHardwareMicMuted(_ muted: Bool) async throws {
-        if state.isActive {
+        if state.isConnected {
             guard let webRTCConnectionManager = activeWebRTCConnectionManager else {
                 throw ConversationError.notConnected
             }
@@ -329,21 +329,21 @@ public final class Conversation: ObservableObject {
 
     /// Interrupt the agent while speaking.
     public func interruptAgent() async throws {
-        guard state.isActive else { throw ConversationError.notConnected }
+        guard state.isConnected else { throw ConversationError.notConnected }
         let event = OutgoingEvent.userActivity
         try await publish(event)
     }
 
     /// Contextual update to agent (system prompt-ish).
     public func updateContext(_ context: String) async throws {
-        guard state.isActive else { throw ConversationError.notConnected }
+        guard state.isConnected else { throw ConversationError.notConnected }
         let event = OutgoingEvent.contextualUpdate(ContextualUpdateEvent(text: context))
         try await publish(event)
     }
 
     /// Send feedback (like/dislike) for an event/message id.
     public func sendFeedback(_ score: FeedbackEvent.Score, eventId: Int) async throws {
-        guard state.isActive else {
+        guard state.isConnected else {
             throw ConversationError.notConnected
         }
 
@@ -358,7 +358,7 @@ public final class Conversation: ObservableObject {
     ///   - toolCallId: The tool call identifier from `MCPToolCallEvent`.
     ///   - isApproved: Pass `true` to approve, `false` to reject.
     public func sendMCPToolApproval(toolCallId: String, isApproved: Bool) async throws {
-        guard state.isActive else { throw ConversationError.notConnected }
+        guard state.isConnected else { throw ConversationError.notConnected }
         let approval = MCPToolApprovalResultEvent(toolCallId: toolCallId, isApproved: isApproved)
         try await publish(.mcpToolApprovalResult(approval))
     }
@@ -385,7 +385,7 @@ public final class Conversation: ObservableObject {
         isError: Bool = false,
         errorType: ClientToolErrorType? = nil
     ) async throws {
-        guard state.isActive else { throw ConversationError.notConnected }
+        guard state.isConnected else { throw ConversationError.notConnected }
         let toolResult = ClientToolResultEvent(
             toolCallId: toolCallId, result: result, isError: isError, errorType: errorType
         )
@@ -447,7 +447,7 @@ public final class Conversation: ObservableObject {
                 guard let self,
                       let connectionManager,
                       activeConnectionManager === connectionManager,
-                      state == .connecting || state.isActive
+                      state == .connecting || state.isConnected
                 else {
                     return
                 }

--- a/Sources/ElevenLabs/Public/Conversation/ConversationState.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationState.swift
@@ -3,12 +3,12 @@ import Foundation
 public enum ConversationState: Equatable, Sendable {
     case idle
     case connecting
-    case active(CallInfo)
+    case connected(CallInfo)
     case ended(reason: EndReason)
     case error(ConversationError)
 
-    public var isActive: Bool {
-        if case .active = self { return true }
+    public var isConnected: Bool {
+        if case .connected = self { return true }
         return false
     }
 
@@ -17,8 +17,8 @@ public enum ConversationState: Equatable, Sendable {
         return false
     }
 
-    var activeAgentId: String? {
-        if case let .active(info) = self { return info.agentId }
+    var connectedAgentId: String? {
+        if case let .connected(info) = self { return info.agentId }
         return nil
     }
 }

--- a/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupState.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupState.swift
@@ -7,6 +7,6 @@ public enum ConversationStartupState: Sendable, Equatable {
     case waitingForAgent(timeout: TimeInterval)
     case agentReady(ConversationAgentReadyReport)
     case sendingConversationInit(attempt: Int)
-    case active(CallInfo, ConversationStartupMetrics)
+    case connected(CallInfo, ConversationStartupMetrics)
     case failed(ConversationStartupFailure, ConversationStartupMetrics)
 }

--- a/Tests/ElevenLabsTests/Integration/ConversationIntegrationTests.swift
+++ b/Tests/ElevenLabsTests/Integration/ConversationIntegrationTests.swift
@@ -40,7 +40,7 @@ final class ConversationIntegrationTests: XCTestCase {
             try await conv.sendMessage("Hello")
         }
 
-        // Mute operations also require active state
+        // Mute operations also require connected state
         await assertThrowsConversationError(.notConnected) {
             try await conv.toggleMicMute()
         }

--- a/Tests/ElevenLabsTests/StartupPerformanceTest.swift
+++ b/Tests/ElevenLabsTests/StartupPerformanceTest.swift
@@ -66,9 +66,9 @@ final class StartupPerformanceTest: XCTestCase {
             print("  [\(String(format: "%.3f", elapsed))s] State: idle")
         case .connecting:
             print("  [\(String(format: "%.3f", elapsed))s] State: connecting")
-        case let .active(info):
+        case let .connected(info):
             hasConnected = true
-            print("  [\(String(format: "%.3f", elapsed))s] State: active (agent: \(info.agentId))")
+            print("  [\(String(format: "%.3f", elapsed))s] State: connected (agent: \(info.agentId))")
             print("  🎯 ACTIVE STATE REACHED in \(String(format: "%.3f", elapsed))s")
         case let .ended(reason):
             print("  [\(String(format: "%.3f", elapsed))s] State: ended (reason: \(reason))")
@@ -87,7 +87,7 @@ final class StartupPerformanceTest: XCTestCase {
 
         print("  [\(String(format: "%.3f", elapsed))s] Agent state: \(conversation.agentState)")
 
-        // The static API should return an already-active conversation
+        // The static API should return an already-connected conversation
         // But let's give it a moment and measure the total time when we called the API
         let totalTime = Date().timeIntervalSince(testStart)
 
@@ -110,12 +110,12 @@ final class StartupPerformanceTest: XCTestCase {
         // Wait for cleanup
         try await Task.sleep(nanoseconds: 500_000_000) // 0.5s
 
-        // Check if we reached active state
-        let reachedActive = conversation.state.isActive
+        // Check if we reached connected state
+        let reachedConnected = conversation.state.isConnected
         if case .ended(reason: .userEnded) = conversation.state {
             // This is fine - we ended it ourselves
-        } else if !reachedActive {
-            throw NSError(domain: "StartupTest", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to reach active state"])
+        } else if !reachedConnected {
+            throw NSError(domain: "StartupTest", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to reach connected state"])
         }
 
         return totalTime
@@ -135,7 +135,7 @@ final class StartupPerformanceTest: XCTestCase {
         let maxTime = timings.max() ?? 0
 
         print("Runs completed: \(timings.count)")
-        print("Average time to active: \(String(format: "%.3f", avgTime))s")
+        print("Average time to connected: \(String(format: "%.3f", avgTime))s")
         print("Fastest time: \(String(format: "%.3f", minTime))s")
         print("Slowest time: \(String(format: "%.3f", maxTime))s")
         print("Range: \(String(format: "%.3f", maxTime - minTime))s")

--- a/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
+++ b/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
@@ -146,7 +146,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
         mockWebRTCConnectionManager.succeedAgentReady()
         try await startTask.value
 
-        XCTAssertEqual(conversation.state, .active(CallInfo(agentId: "new-agent")))
+        XCTAssertEqual(conversation.state, .connected(CallInfo(agentId: "new-agent")))
     }
 
     // MARK: - Audio Alignment

--- a/Tests/ElevenLabsTests/Unit/ConversationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationTests.swift
@@ -42,11 +42,11 @@ final class ConversationTests: XCTestCase {
     }
 
     func testStartConversationSuccessUpdatesStartupState() async throws {
-        let stateExpectation = expectation(description: "startup becomes active")
+        let stateExpectation = expectation(description: "startup becomes connected")
 
         let config = makeConfig()
         let callbacks = makeCallbacks(onStartupStateChange: { state in
-            if case .active = state {
+            if case .connected = state {
                 stateExpectation.fulfill()
             }
         })
@@ -61,9 +61,9 @@ final class ConversationTests: XCTestCase {
 
         XCTAssertEqual(mockWebRTCConnectionManager.connectCallCount, 1)
         XCTAssertFalse(mockWebRTCConnectionManager.publishedPayloads.isEmpty)
-        XCTAssertEqual(conversation.state, .active(.init(agentId: "test-agent-id")))
-        guard case let .active(callInfo, metrics) = conversation.startupState else {
-            return XCTFail("Expected active startup state")
+        XCTAssertEqual(conversation.state, ConversationState.connected(.init(agentId: "test-agent-id")))
+        guard case let .connected(callInfo, metrics) = conversation.startupState else {
+            return XCTFail("Expected connected startup state")
         }
         XCTAssertEqual(callInfo.agentId, "test-agent-id")
         XCTAssertEqual(metrics.conversationInitAttempts, 1)
@@ -190,7 +190,7 @@ final class ConversationTests: XCTestCase {
         )
         XCTAssertFalse(mockWebSocketConnectionManager.sentPayloads.isEmpty)
         XCTAssertEqual(try sentEventType(from: mockWebSocketConnectionManager.sentPayloads[0]), "conversation_initiation_client_data")
-        XCTAssertEqual(conversation.state, .active(.init(agentId: "test-agent-id")))
+        XCTAssertEqual(conversation.state, ConversationState.connected(.init(agentId: "test-agent-id")))
 
         let payload: [String: Any] = [
             "type": "agent_response",
@@ -232,7 +232,7 @@ final class ConversationTests: XCTestCase {
         XCTAssertNil(mockWebRTCConnectionManager.onDisconnected)
         XCTAssertNil(mockWebRTCConnectionManager.onRemoteSpeakingChanged)
         XCTAssertEqual(mockWebSocketConnectionManager.connectCallCount, 1)
-        XCTAssertEqual(conversation.state, .active(.init(agentId: "test-agent-id")))
+        XCTAssertEqual(conversation.state, ConversationState.connected(.init(agentId: "test-agent-id")))
     }
 
     func testStartTextOnlySignedURLUsesProvidedWebSocketURL() async throws {
@@ -250,7 +250,7 @@ final class ConversationTests: XCTestCase {
         XCTAssertEqual(mockWebSocketConnectionManager.connectCallCount, 1)
         XCTAssertEqual(mockWebSocketConnectionManager.lastConnectedURL?.absoluteString, signedURL)
         XCTAssertFalse(mockWebSocketConnectionManager.sentPayloads.isEmpty)
-        XCTAssertEqual(conversation.state, .active(.init(agentId: "agent-private")))
+        XCTAssertEqual(conversation.state, ConversationState.connected(.init(agentId: "agent-private")))
     }
 
     func testSignedWebSocketURLRejectsURLWithoutAgentId() {
@@ -608,8 +608,8 @@ final class ConversationTests: XCTestCase {
     }
 
     @MainActor
-    func testEndConversationWhenNotActive() async {
-        // Should not throw error when ending inactive conversation
+    func testEndConversationWhenNotConnected() async {
+        // Should not throw error when ending a non-connected conversation
         await conversation.endConversation()
         XCTAssertEqual(conversation.state, .idle)
     }
@@ -628,11 +628,11 @@ final class ConversationTests: XCTestCase {
     func testConversationStateEnum() {
         let idleState: ConversationState = .idle
         let connectingState: ConversationState = .connecting
-        let activeState: ConversationState = .active(CallInfo(agentId: "test"))
+        let connectedState: ConversationState = .connected(CallInfo(agentId: "test"))
 
         XCTAssertNotEqual(idleState, connectingState)
-        XCTAssertNotEqual(connectingState, activeState)
-        XCTAssertNotEqual(idleState, activeState)
+        XCTAssertNotEqual(connectingState, connectedState)
+        XCTAssertNotEqual(idleState, connectedState)
     }
 
     func testFeedbackTypeEnum() {
@@ -656,7 +656,7 @@ final class ConversationTests: XCTestCase {
             auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
             config: config
         )
-        XCTAssertEqual(conversation.state, .active(.init(agentId: "test-agent-id")))
+        XCTAssertEqual(conversation.state, ConversationState.connected(.init(agentId: "test-agent-id")))
         let disconnectsBefore = mockWebRTCConnectionManager.disconnectCallCount
 
         await mockWebRTCConnectionManager.onDisconnected?()

--- a/Tests/ElevenLabsTests/Unit/ErrorHandlingIntegrationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ErrorHandlingIntegrationTests.swift
@@ -139,15 +139,15 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
             // Verify no errors were reported
             XCTAssertTrue(capturedErrors.isEmpty, "Error array should be empty")
 
-            // Verify connection is active
-            XCTAssertTrue(conversation.state.isActive, "Conversation should be active")
+            // Verify connection is established
+            XCTAssertTrue(conversation.state.isConnected, "Conversation should be connected")
 
             print("\n📊 Startup states (\(capturedStartupStates.count)):")
             for (index, state) in capturedStartupStates.enumerated() {
                 print("  \(index + 1). \(state)")
             }
 
-            if case let .active(_, metrics) = conversation.startupState {
+            if case let .connected(_, metrics) = conversation.startupState {
                 print("\n⏱️ Startup metrics:")
                 print("  Total: \(String(format: "%.3f", metrics.total ?? 0))s")
                 print("  Token fetch: \(String(format: "%.3f", metrics.tokenFetch ?? 0))s")
@@ -261,7 +261,7 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
                 )
 
                 print("  ✅ Connection \(attempt) successful")
-                XCTAssertTrue(conversation.state.isActive)
+                XCTAssertTrue(conversation.state.isConnected)
 
                 // Brief interaction
                 try? await conversation.sendMessage("Test message \(attempt)")


### PR DESCRIPTION
## Summary
- Rename `ConversationState.active` to `connected` and update the public helper from `isActive` to `isConnected`. "active" is confusing because connecting state can also be thought of as "active". "connected" leaves no doubts.
- Rename the final startup state from `ConversationStartupState.active` to `connected` for consistent lifecycle naming.
- Update docs and tests to use the connected-state terminology.

## Testing
- Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a source-breaking public API rename; integrators must update switches and any use of `isActive` / `.active`, though runtime behavior is unchanged aside from naming.
> 
> **Overview**
> **Breaking rename** of the post-handshake conversation lifecycle: `ConversationState.active` becomes **`connected`**, the public helper **`isActive`** becomes **`isConnected`**, and **`ConversationStartupState.active`** becomes **`connected`** so startup and runtime state use the same term.
> 
> `Conversation` now sets **`connected`** after a successful start and gates messaging, mic control, tools, feedback, and related APIs on **`state.isConnected`** (still allowing **`endConversation`** while **`connecting`**). Internal **`activeAgentId`** is renamed **`connectedAgentId`**.
> 
> Docs (**README**, **Usage**) and unit/integration tests are updated to match the new enum cases and property names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f283f52daa69c3bf2c5965171e55586eca3d3379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->