### PR TITLE
refactor: nest startup progress under ConversationState

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -64,7 +64,8 @@ conversation.$agentState
 
 ### Connection State
 
-Handle transitions between idle, connecting, connected, and ended states.
+Handle transitions between idle, connecting, connected, ended, and error states.
+Startup stages are nested under `.connecting`.
 
 ```swift
 conversation.$state
@@ -72,10 +73,11 @@ conversation.$state
         switch state {
         case .idle:
             break
-        case .connecting:
-            break
-        case .connected(let callInfo):
+        case .connecting(let stage):
+            print("Connecting: \(stage)")
+        case .connected(let callInfo, let metrics):
             print("Connected to agent: \(callInfo.agentId)")
+            print("Startup took \(metrics.total ?? 0)s")
         case .ended(let reason):
             print("Conversation ended: \(reason)")
         case .error(let error):
@@ -609,7 +611,7 @@ class ReconnectionManager: ObservableObject {
                     self.showReconnectButton = false
                     self.isReconnecting = false
                     self.reconnectAttempts = 0
-                default:
+                case .idle, .connecting, .error:
                     break
                 }
             }

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -75,9 +75,8 @@ conversation.$state
             break
         case .connecting(let stage):
             print("Connecting: \(stage)")
-        case .connected(let callInfo, let metrics):
+        case .connected(let callInfo):
             print("Connected to agent: \(callInfo.agentId)")
-            print("Startup took \(metrics.total ?? 0)s")
         case .ended(let reason):
             print("Conversation ended: \(reason)")
         case .error(let error):

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ struct ChatView: View {
                     switch conversation.state {
                     case .idle: Text("Status: idle")
                     case .connecting: Text("Status: connecting")
-                    case .connected(let info, _): Text("Connected to: \(info.agentId)")
+                    case .connected(let info): Text("Connected to: \(info.agentId)")
                     case .ended: Text("Status: ended")
                     case .error: Text("Status: error")
                     }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ struct ChatView: View {
                     switch conversation.state {
                     case .idle: Text("Status: idle")
                     case .connecting: Text("Status: connecting")
-                    case .connected(let info): Text("Connected to: \(info.agentId)")
+                    case .connected(let info, _): Text("Connected to: \(info.agentId)")
                     case .ended: Text("Status: ended")
                     case .error: Text("Status: error")
                     }

--- a/Sources/ElevenLabs/Internal/Conversation/ConnectionManaging.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/ConnectionManaging.swift
@@ -10,26 +10,24 @@ protocol ConnectionManaging: AnyObject {
     var onDisconnected: (() async -> Void)? { get set }
     var errorHandler: ((Swift.Error?) -> Void)? { get set }
 
-    func disconnect() async
-    func send(data: Data) async throws
-}
-
-protocol WebSocketConnectionManaging: ConnectionManaging {
-    func connect(auth: ConversationCredentials, config: ConversationConfig) async throws -> StartupResult
-}
-
-protocol WebRTCConnectionManaging: ConnectionManaging {
-    var onRemoteSpeakingChanged: (@Sendable (Bool) -> Void)? { get set }
-    var inputTrack: LocalAudioTrack? { get }
-    var agentAudioTrack: RemoteAudioTrack? { get }
-    var isMicrophoneMuted: Bool { get }
-
     @MainActor
     func connect(
         auth: ConversationCredentials,
         config: ConversationConfig,
         onStartupStateChange: @escaping (ConversationStartupState) -> Void
     ) async throws -> StartupResult
+
+    func disconnect() async
+    func send(data: Data) async throws
+}
+
+protocol WebSocketConnectionManaging: ConnectionManaging {}
+
+protocol WebRTCConnectionManaging: ConnectionManaging {
+    var onRemoteSpeakingChanged: (@Sendable (Bool) -> Void)? { get set }
+    var inputTrack: LocalAudioTrack? { get }
+    var agentAudioTrack: RemoteAudioTrack? { get }
+    var isMicrophoneMuted: Bool { get }
 
     func setMicrophoneMuted(_ muted: Bool) async throws
 }

--- a/Sources/ElevenLabs/Internal/Conversation/ConnectionManaging.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/ConnectionManaging.swift
@@ -15,7 +15,7 @@ protocol ConnectionManaging: AnyObject {
         auth: ConversationCredentials,
         config: ConversationConfig,
         onStartupStateChange: @escaping (ConversationStartupState) -> Void
-    ) async throws -> StartupResult
+    ) async throws -> ConversationStartResult
 
     func disconnect() async
     func send(data: Data) async throws

--- a/Sources/ElevenLabs/Internal/Conversation/StartupResult.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/StartupResult.swift
@@ -4,25 +4,3 @@ struct StartupResult {
     let agentId: String
     let metrics: ConversationStartupMetrics
 }
-
-struct StartupFailure: Error {
-    let reason: ConversationStartupFailure
-    let error: ConversationError
-    let metrics: ConversationStartupMetrics
-
-    static func token(_ error: ConversationError, _ metrics: ConversationStartupMetrics) -> Self {
-        .init(reason: .token(error), error: error, metrics: metrics)
-    }
-
-    static func room(_ error: ConversationError, _ metrics: ConversationStartupMetrics) -> Self {
-        .init(reason: .room(error), error: error, metrics: metrics)
-    }
-
-    static func agentTimeout(_ metrics: ConversationStartupMetrics) -> Self {
-        .init(reason: .agentTimeout, error: .agentTimeout, metrics: metrics)
-    }
-
-    static func conversationInit(_ error: ConversationError, _ metrics: ConversationStartupMetrics) -> Self {
-        .init(reason: .conversationInit(error), error: error, metrics: metrics)
-    }
-}

--- a/Sources/ElevenLabs/Internal/Conversation/StartupResult.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/StartupResult.swift
@@ -1,6 +1,0 @@
-import Foundation
-
-struct StartupResult {
-    let agentId: String
-    let metrics: ConversationStartupMetrics
-}

--- a/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
@@ -78,7 +78,7 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
         auth: ConversationCredentials,
         config: ConversationConfig,
         onStartupStateChange: @escaping (ConversationStartupState) -> Void
-    ) async throws -> StartupResult {
+    ) async throws -> ConversationStartResult {
         let startTime = Date()
         var metrics = ConversationStartupMetrics()
         logger.info("Starting conversation startup sequence", context: ["agentId": auth.agentId])
@@ -128,7 +128,10 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
         }
 
         metrics.total = Date().timeIntervalSince(startTime)
-        return StartupResult(agentId: auth.agentId, metrics: metrics)
+        return ConversationStartResult(
+            callInfo: CallInfo(agentId: auth.agentId),
+            metrics: metrics
+        )
     }
 
     /// Race the delegate's "first remote participant joined" signal against `timeout`.

--- a/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
@@ -86,7 +86,7 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
         // 1. Resolve token / connection details.
         onStartupStateChange(.resolvingToken)
         let connectionDetails = try await runPhase(
-            timing: \.tokenFetch, metrics: &metrics, startTime: startTime, failure: StartupFailure.token
+            timing: \.tokenFetch, metrics: &metrics, startTime: startTime
         ) {
             try await tokenService.fetchConnectionDetails(configuration: auth)
         }
@@ -98,7 +98,7 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
         onStartupStateChange(.connectingRoom)
         let throwOnMicFailure = !config.continueWithoutMicrophoneOnFailure
         try await runPhase(
-            timing: \.roomConnect, metrics: &metrics, startTime: startTime, failure: StartupFailure.room
+            timing: \.roomConnect, metrics: &metrics, startTime: startTime
         ) {
             try await connectToRoom(
                 details: connectionDetails,
@@ -114,27 +114,25 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
         guard case let .success(elapsed) = await waitForAgentReady(timeout: agentTimeout) else {
             metrics.total = Date().timeIntervalSince(startTime)
             logger.warning("Agent not ready within \(String(format: "%.3f", agentTimeout))s")
-            throw StartupFailure.agentTimeout(metrics)
+            throw ConversationError.agentTimeout
         }
         metrics.agentReady = elapsed
         onStartupStateChange(.agentReady(ConversationAgentReadyReport(elapsed: elapsed)))
 
         // 5. Send conversation_initiation_client_data (sent once).
-        onStartupStateChange(.sendingConversationInit(attempt: 1))
+        onStartupStateChange(.sendingConversationInit)
         try await runPhase(
-            timing: \.conversationInit, metrics: &metrics, startTime: startTime,
-            failure: StartupFailure.conversationInit
+            timing: \.conversationInit, metrics: &metrics, startTime: startTime
         ) {
             try await send(event: .conversationInit(ConversationInitEvent(config: config)))
         }
-        metrics.conversationInitAttempts = 1
 
         metrics.total = Date().timeIntervalSince(startTime)
         return StartupResult(agentId: auth.agentId, metrics: metrics)
     }
 
     /// Race the delegate's "first remote participant joined" signal against `timeout`.
-    /// A `.timedOut` result makes `connect` fail with `StartupFailure.agentTimeout`.
+    /// A `.timedOut` result makes `connect` fail with `ConversationError.agentTimeout`.
     private func waitForAgentReady(timeout: TimeInterval) async -> AgentReadyWaitResult {
         guard let delegate = readinessDelegate else {
             return .timedOut(elapsed: 0)
@@ -271,14 +269,13 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
     // MARK: – Private helpers
 
     /// Run one timed startup phase: record its duration into `metrics[keyPath:]`,
-    /// let `CancellationError` propagate unwrapped, and wrap any other error via
-    /// `failure` (stamping `total`).
+    /// let `CancellationError` propagate unwrapped, and wrap any other error as
+    /// `ConversationError` (stamping `total`).
     @MainActor
     private func runPhase<T>(
         timing keyPath: WritableKeyPath<ConversationStartupMetrics, TimeInterval?>,
         metrics: inout ConversationStartupMetrics,
         startTime: Date,
-        failure: (ConversationError, ConversationStartupMetrics) -> StartupFailure,
         _ body: () async throws -> T
     ) async throws -> T {
         let start = Date()
@@ -293,7 +290,7 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
         } catch {
             metrics[keyPath: keyPath] = Date().timeIntervalSince(start)
             metrics.total = Date().timeIntervalSince(startTime)
-            throw failure(error as? ConversationError ?? .connectionFailed(error), metrics)
+            throw error as? ConversationError ?? ConversationError.connectionFailed(error)
         }
     }
 

--- a/Sources/ElevenLabs/Internal/Networking/WebSocketConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebSocketConnectionManager.swift
@@ -29,7 +29,12 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
         urlSession.invalidateAndCancel()
     }
 
-    func connect(auth: ConversationCredentials, config: ConversationConfig) async throws -> StartupResult {
+    @MainActor
+    func connect(
+        auth: ConversationCredentials,
+        config: ConversationConfig,
+        onStartupStateChange: @escaping (ConversationStartupState) -> Void
+    ) async throws -> StartupResult {
         let startTime = Date()
         var metrics = ConversationStartupMetrics()
 
@@ -39,7 +44,7 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
         } catch {
             metrics.total = Date().timeIntervalSince(startTime)
             let convError = error as? ConversationError ?? .authenticationFailed(error.localizedDescription)
-            throw StartupFailure.token(convError, metrics)
+            throw convError
         }
 
         let task = urlSession.webSocketTask(with: url)
@@ -48,6 +53,7 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
 
         // The first send awaits the WebSocket handshake internally —
         // any connection failure surfaces here.
+        onStartupStateChange(.sendingConversationInit)
         do {
             let initEvent = ConversationInitEvent(config: config)
             try await send(data: EventSerializer.serializeOutgoingEvent(.conversationInit(initEvent)))
@@ -57,8 +63,7 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
         } catch {
             tearDownTask(task)
             metrics.total = Date().timeIntervalSince(startTime)
-            let convError = error as? ConversationError ?? .connectionFailed(error)
-            throw StartupFailure.conversationInit(convError, metrics)
+            throw error as? ConversationError ?? ConversationError.connectionFailed(error)
         }
 
         // Socket is up and the init message is sent. Start consuming responses.
@@ -67,7 +72,6 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
             await receiveLoop(task: task)
         }
 
-        metrics.conversationInitAttempts = 1
         metrics.total = Date().timeIntervalSince(startTime)
         return StartupResult(agentId: auth.agentId, metrics: metrics)
     }

--- a/Sources/ElevenLabs/Internal/Networking/WebSocketConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebSocketConnectionManager.swift
@@ -34,7 +34,7 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
         auth: ConversationCredentials,
         config: ConversationConfig,
         onStartupStateChange: @escaping (ConversationStartupState) -> Void
-    ) async throws -> StartupResult {
+    ) async throws -> ConversationStartResult {
         let startTime = Date()
         var metrics = ConversationStartupMetrics()
 
@@ -73,7 +73,10 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
         }
 
         metrics.total = Date().timeIntervalSince(startTime)
-        return StartupResult(agentId: auth.agentId, metrics: metrics)
+        return ConversationStartResult(
+            callInfo: CallInfo(agentId: auth.agentId),
+            metrics: metrics
+        )
     }
 
     func send(data: Data) async throws {

--- a/Sources/ElevenLabs/Public/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Conversation.swift
@@ -20,8 +20,6 @@ public final class Conversation: ObservableObject {
     // MARK: - Public State
 
     @Published public internal(set) var state: ConversationState = .idle
-    @Published public internal(set) var startupState: ConversationStartupState = .idle
-    @Published public internal(set) var startupMetrics: ConversationStartupMetrics?
     @Published public internal(set) var messages: [Message] = []
     @Published public internal(set) var agentState: ElevenLabs.AgentState = .listening
     @Published public internal(set) var isMicMuted: Bool = true
@@ -157,7 +155,7 @@ public final class Conversation: ObservableObject {
         auth: ConversationCredentials,
         config: ConversationConfig = .init()
     ) async throws {
-        guard state == .idle || state.isEnded else {
+        guard state == .idle || state.isEnded || state.isError else {
             throw ConversationError.alreadyActive
         }
 
@@ -167,9 +165,7 @@ public final class Conversation: ObservableObject {
             try await startVoiceConversation(auth: auth, config: config, provider: dependencyProvider)
         }
 
-        state = .connected(.init(agentId: result.agentId))
-        startupMetrics = result.metrics
-        updateStartupState(.connected(CallInfo(agentId: result.agentId), result.metrics))
+        state = .connected(CallInfo(agentId: result.agentId), result.metrics)
         callbacks.onAgentReady?()
     }
 
@@ -200,13 +196,13 @@ public final class Conversation: ObservableObject {
             result = try await webRTCConnectionManager.connect(
                 auth: auth,
                 config: config,
-                onStartupStateChange: { [weak self] newState in
-                    self?.updateStartupState(newState)
+                onStartupStateChange: { [weak self] stage in
+                    self?.updateStartupStage(stage)
                 }
             )
-        } catch let failure as StartupFailure {
-            await handleStartupFailure(failure, disconnecting: webRTCConnectionManager)
-            throw failure.error
+        } catch let error as ConversationError {
+            await handleStartupFailure(error, disconnecting: webRTCConnectionManager)
+            throw error
         } catch is CancellationError {
             await handleStartupCancellation(disconnecting: webRTCConnectionManager)
             throw CancellationError()
@@ -237,13 +233,17 @@ public final class Conversation: ObservableObject {
             connectionManager: connectionManager
         )
 
-        updateStartupState(.connectingRoom)
-
         do {
-            return try await connectionManager.connect(auth: auth, config: config)
-        } catch let failure as StartupFailure {
-            await handleStartupFailure(failure, disconnecting: connectionManager)
-            throw failure.error
+            return try await connectionManager.connect(
+                auth: auth,
+                config: config,
+                onStartupStateChange: { [weak self] stage in
+                    self?.updateStartupStage(stage)
+                }
+            )
+        } catch let error as ConversationError {
+            await handleStartupFailure(error, disconnecting: connectionManager)
+            throw error
         } catch is CancellationError {
             await handleStartupCancellation(disconnecting: connectionManager)
             throw CancellationError()
@@ -258,10 +258,10 @@ public final class Conversation: ObservableObject {
 
     private func endConversation(disconnectReason: DisconnectionReason = .user, endReason: EndReason = .userEnded) async {
         // Allow ending during both connected and connecting states
-        guard state.isConnected || state == .connecting else { return }
+        guard state.isConnected || state.isConnecting else { return }
         guard let connectionManager = activeConnectionManager else {
             // No connection manager yet, just reset state
-            if state == .connecting {
+            if state.isConnecting {
                 state = .idle
                 tearDownActiveSession()
             }
@@ -318,7 +318,7 @@ public final class Conversation: ObservableObject {
             } catch {
                 throw ConversationError.microphoneToggleFailed(error)
             }
-        } else if state == .connecting {
+        } else if state.isConnecting {
             // Buffer the mute state to apply after connection completes
             pendingMuteState = muted
             isMicMuted = muted
@@ -411,9 +411,10 @@ public final class Conversation: ObservableObject {
 
     var speakingTimer: Task<Void, Never>?
 
-    private func updateStartupState(_ newState: ConversationStartupState) {
-        startupState = newState
-        callbacks.onStartupStateChange?(newState)
+    private func updateStartupStage(_ stage: ConversationStartupState) {
+        if state != .connecting(stage) {
+            state = .connecting(stage)
+        }
     }
 
     /// Common preparation shared by voice and text-only startup paths.
@@ -423,7 +424,7 @@ public final class Conversation: ObservableObject {
         connectionManager: any ConnectionManaging
     ) async {
         let previousConnectionManager = activeConnectionManager
-        state = .connecting
+        state = .connecting(.preparing)
 
         if let previousConnectionManager, previousConnectionManager !== connectionManager {
             await previousConnectionManager.disconnect()
@@ -447,7 +448,7 @@ public final class Conversation: ObservableObject {
                 guard let self,
                       let connectionManager,
                       activeConnectionManager === connectionManager,
-                      state == .connecting || state.isConnected
+                      state.isConnecting || state.isConnected
                 else {
                     return
                 }
@@ -462,24 +463,20 @@ public final class Conversation: ObservableObject {
     }
 
     private func handleStartupFailure(
-        _ failure: StartupFailure,
+        _ error: ConversationError,
         disconnecting connectionManager: any ConnectionManaging
     ) async {
         cleanupTransientResources()
         await connectionManager.disconnect()
 
-        startupMetrics = failure.metrics
-        state = .idle
-        updateStartupState(.failed(failure.reason, failure.metrics))
-        callbacks.onError?(failure.error)
+        state = .error(error)
+        callbacks.onError?(error)
     }
 
     private func handleStartupCancellation(disconnecting connectionManager: any ConnectionManaging) async {
         cleanupTransientResources()
         await connectionManager.disconnect()
-        startupMetrics = nil
         state = .idle
-        updateStartupState(.idle)
     }
 
     /// Clean up state from any previous conversation to ensure a fresh start.
@@ -491,9 +488,6 @@ public final class Conversation: ObservableObject {
         mcpToolCalls.removeAll()
         mcpConnectionStatus = nil
         conversationMetadata = nil
-
-        startupState = .idle
-        startupMetrics = nil
 
         logger.debug("Previous conversation state cleaned up for fresh Room", context: activeContext)
     }

--- a/Sources/ElevenLabs/Public/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Conversation.swift
@@ -161,26 +161,22 @@ public final class Conversation: ObservableObject {
             throw ConversationError.alreadyActive
         }
 
-        let result: StartupResult = if config.conversationOverrides.textOnly {
+        let result: ConversationStartResult = if config.conversationOverrides.textOnly {
             try await startTextOnlyConversation(auth: auth, config: config, provider: dependencyProvider)
         } else {
             try await startVoiceConversation(auth: auth, config: config, provider: dependencyProvider)
         }
 
-        let startResult = ConversationStartResult(
-            callInfo: CallInfo(agentId: result.agentId),
-            metrics: result.metrics
-        )
-        state = .connected(startResult.callInfo)
+        state = .connected(result.callInfo)
         callbacks.onAgentReady?()
-        return startResult
+        return result
     }
 
     private func startVoiceConversation(
         auth: ConversationCredentials,
         config: ConversationConfig,
         provider: any ConversationDependencyProvider
-    ) async throws -> StartupResult {
+    ) async throws -> ConversationStartResult {
         let webRTCConnectionManager = provider.webRTCConnectionManager
         await prepareConversationStart(
             auth: auth, config: config,
@@ -198,7 +194,7 @@ public final class Conversation: ObservableObject {
         }
         await audioManager?.configure(with: config, callbacks: callbacks)
 
-        let result: StartupResult
+        let result: ConversationStartResult
         do {
             result = try await webRTCConnectionManager.connect(
                 auth: auth,
@@ -233,7 +229,7 @@ public final class Conversation: ObservableObject {
         auth: ConversationCredentials,
         config: ConversationConfig,
         provider: ConversationDependencyProvider
-    ) async throws -> StartupResult {
+    ) async throws -> ConversationStartResult {
         let connectionManager = provider.webSocketConnectionManager
         await prepareConversationStart(
             auth: auth, config: config,

--- a/Sources/ElevenLabs/Public/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Conversation.swift
@@ -139,22 +139,24 @@ public final class Conversation: ObservableObject {
     ///
     /// Each call to this method creates a fresh Room object, ensuring clean state
     /// and preventing any interference from previous conversations.
+    @discardableResult
     public func startConversation(
         with agentId: String,
         config: ConversationConfig = .init()
-    ) async throws {
+    ) async throws -> ConversationStartResult {
         let authConfig = ConversationCredentials.publicAgent(id: agentId, environment: config.environment)
-        try await startConversation(auth: authConfig, config: config)
+        return try await startConversation(auth: authConfig, config: config)
     }
 
     /// Start a conversation using authentication configuration.
     ///
     /// Each call to this method creates a fresh Room object, ensuring clean state
     /// and preventing any interference from previous conversations.
+    @discardableResult
     public func startConversation(
         auth: ConversationCredentials,
         config: ConversationConfig = .init()
-    ) async throws {
+    ) async throws -> ConversationStartResult {
         guard state == .idle || state.isEnded || state.isError else {
             throw ConversationError.alreadyActive
         }
@@ -165,8 +167,13 @@ public final class Conversation: ObservableObject {
             try await startVoiceConversation(auth: auth, config: config, provider: dependencyProvider)
         }
 
-        state = .connected(CallInfo(agentId: result.agentId), result.metrics)
+        let startResult = ConversationStartResult(
+            callInfo: CallInfo(agentId: result.agentId),
+            metrics: result.metrics
+        )
+        state = .connected(startResult.callInfo)
         callbacks.onAgentReady?()
+        return startResult
     }
 
     private func startVoiceConversation(

--- a/Sources/ElevenLabs/Public/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Conversation.swift
@@ -413,9 +413,8 @@ public final class Conversation: ObservableObject {
     var speakingTimer: Task<Void, Never>?
 
     private func updateStartupStage(_ stage: ConversationStartupState) {
-        if state != .connecting(stage) {
-            state = .connecting(stage)
-        }
+        guard state.isConnecting, state != .connecting(stage) else { return }
+        state = .connecting(stage)
     }
 
     /// Common preparation shared by voice and text-only startup paths.

--- a/Sources/ElevenLabs/Public/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Conversation.swift
@@ -139,7 +139,6 @@ public final class Conversation: ObservableObject {
     ///
     /// Each call to this method creates a fresh Room object, ensuring clean state
     /// and preventing any interference from previous conversations.
-    @discardableResult
     public func startConversation(
         with agentId: String,
         config: ConversationConfig = .init()
@@ -152,7 +151,6 @@ public final class Conversation: ObservableObject {
     ///
     /// Each call to this method creates a fresh Room object, ensuring clean state
     /// and preventing any interference from previous conversations.
-    @discardableResult
     public func startConversation(
         auth: ConversationCredentials,
         config: ConversationConfig = .init()

--- a/Sources/ElevenLabs/Public/Conversation/ConversationCallbacks.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationCallbacks.swift
@@ -8,9 +8,6 @@ public struct ConversationCallbacks: Sendable {
     /// Called when the agent disconnects or the conversation ends
     public var onDisconnect: (@Sendable (DisconnectionReason) -> Void)?
 
-    /// Called whenever the startup state transitions
-    public var onStartupStateChange: (@Sendable (ConversationStartupState) -> Void)?
-
     /// Called when a startup-related error occurs
     public var onError: (@Sendable (ConversationError) -> Void)?
 
@@ -60,7 +57,6 @@ public struct ConversationCallbacks: Sendable {
     public init(
         onAgentReady: (@Sendable () -> Void)? = nil,
         onDisconnect: (@Sendable (DisconnectionReason) -> Void)? = nil,
-        onStartupStateChange: (@Sendable (ConversationStartupState) -> Void)? = nil,
         onError: (@Sendable (ConversationError) -> Void)? = nil,
         onSpeechDetectedWhileMuted: (@Sendable () -> Void)? = nil,
         onAgentResponse: (@Sendable (_ text: String, _ eventId: Int) -> Void)? = nil,
@@ -79,7 +75,6 @@ public struct ConversationCallbacks: Sendable {
     ) {
         self.onAgentReady = onAgentReady
         self.onDisconnect = onDisconnect
-        self.onStartupStateChange = onStartupStateChange
         self.onError = onError
         self.onSpeechDetectedWhileMuted = onSpeechDetectedWhileMuted
         self.onAgentResponse = onAgentResponse

--- a/Sources/ElevenLabs/Public/Conversation/ConversationState.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationState.swift
@@ -3,7 +3,7 @@ import Foundation
 public enum ConversationState: Equatable, Sendable {
     case idle
     case connecting(ConversationStartupState)
-    case connected(CallInfo, ConversationStartupMetrics)
+    case connected(CallInfo)
     case ended(reason: EndReason)
     case error(ConversationError)
 
@@ -28,7 +28,7 @@ public enum ConversationState: Equatable, Sendable {
     }
 
     var connectedAgentId: String? {
-        if case let .connected(info, _) = self { return info.agentId }
+        if case let .connected(info) = self { return info.agentId }
         return nil
     }
 }

--- a/Sources/ElevenLabs/Public/Conversation/ConversationState.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationState.swift
@@ -2,10 +2,15 @@ import Foundation
 
 public enum ConversationState: Equatable, Sendable {
     case idle
-    case connecting
-    case connected(CallInfo)
+    case connecting(ConversationStartupState)
+    case connected(CallInfo, ConversationStartupMetrics)
     case ended(reason: EndReason)
     case error(ConversationError)
+
+    public var isConnecting: Bool {
+        if case .connecting = self { return true }
+        return false
+    }
 
     public var isConnected: Bool {
         if case .connected = self { return true }
@@ -17,8 +22,13 @@ public enum ConversationState: Equatable, Sendable {
         return false
     }
 
+    var isError: Bool {
+        if case .error = self { return true }
+        return false
+    }
+
     var connectedAgentId: String? {
-        if case let .connected(info) = self { return info.agentId }
+        if case let .connected(info, _) = self { return info.agentId }
         return nil
     }
 }

--- a/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartResult.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartResult.swift
@@ -1,0 +1,4 @@
+public struct ConversationStartResult: Equatable, Sendable {
+    public let callInfo: CallInfo
+    public let metrics: ConversationStartupMetrics
+}

--- a/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupFailure.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupFailure.swift
@@ -1,8 +1,0 @@
-import Foundation
-
-public enum ConversationStartupFailure: Sendable, Equatable {
-    case token(ConversationError)
-    case room(ConversationError)
-    case agentTimeout
-    case conversationInit(ConversationError)
-}

--- a/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupMetrics.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupMetrics.swift
@@ -8,7 +8,6 @@ public struct ConversationStartupMetrics: Sendable, Equatable {
 
     public var agentReadyBuffer: TimeInterval?
     public var conversationInit: TimeInterval?
-    public var conversationInitAttempts: Int
 
     public init(
         total: TimeInterval? = nil,
@@ -18,8 +17,7 @@ public struct ConversationStartupMetrics: Sendable, Equatable {
         agentReadyViaGraceTimeout _: Bool = false,
         agentReadyTimedOut _: Bool = false,
         agentReadyBuffer: TimeInterval? = nil,
-        conversationInit: TimeInterval? = nil,
-        conversationInitAttempts: Int = 0
+        conversationInit: TimeInterval? = nil
     ) {
         self.total = total
         self.tokenFetch = tokenFetch
@@ -27,6 +25,5 @@ public struct ConversationStartupMetrics: Sendable, Equatable {
         self.agentReady = agentReady
         self.agentReadyBuffer = agentReadyBuffer
         self.conversationInit = conversationInit
-        self.conversationInitAttempts = conversationInitAttempts
     }
 }

--- a/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupState.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupState.swift
@@ -1,12 +1,12 @@
 import Foundation
 
+/// In-flight startup stage while `ConversationState` is `.connecting`.
 public enum ConversationStartupState: Sendable, Equatable {
-    case idle
+    /// Session teardown / wiring before transport-specific stages begin.
+    case preparing
     case resolvingToken
     case connectingRoom
     case waitingForAgent(timeout: TimeInterval)
     case agentReady(ConversationAgentReadyReport)
-    case sendingConversationInit(attempt: Int)
-    case connected(CallInfo, ConversationStartupMetrics)
-    case failed(ConversationStartupFailure, ConversationStartupMetrics)
+    case sendingConversationInit
 }

--- a/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
+++ b/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
@@ -178,7 +178,7 @@ public enum ElevenLabs {
         callbacks: ConversationCallbacks = .init()
     ) async throws -> Conversation {
         let conversation = createConversation(config: config, callbacks: callbacks)
-        try await conversation.startConversation(
+        _ = try await conversation.startConversation(
             auth: auth, config: config
         )
         return conversation

--- a/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
+++ b/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
@@ -112,6 +112,7 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
         room = nil
     }
 
+    @MainActor
     func waitForAgentReady(timeout: TimeInterval) async -> AgentReadyWaitResult {
         lastWaitTimeout = timeout
         if let pending = pendingWaitResult {
@@ -161,19 +162,23 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
     }
 
     /// Suspends until `onEventReceived` is set.
+    @MainActor
     func waitForEventHandlerInstalled() async {
         if onEventReceived != nil { return }
         await withCheckedContinuation { eventHandlerInstalled = $0 }
     }
 
+    @MainActor
     func succeedAgentReady(elapsed: TimeInterval = 0.1) {
         resumeWait(with: .success(elapsed: elapsed))
     }
 
+    @MainActor
     func timeoutAgentReady(elapsed: TimeInterval = 0.1) {
         resumeWait(with: .timedOut(elapsed: elapsed))
     }
 
+    @MainActor
     private func resumeWait(with result: AgentReadyWaitResult) {
         if let continuation = waitContinuation {
             waitContinuation = nil

--- a/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
+++ b/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
@@ -57,7 +57,7 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
         auth: ConversationCredentials,
         config: ConversationConfig,
         onStartupStateChange: @escaping (ConversationStartupState) -> Void
-    ) async throws -> StartupResult {
+    ) async throws -> ConversationStartResult {
         connectCallCount += 1
         lastNetworkConfiguration = config.networkConfiguration
         var metrics = ConversationStartupMetrics()
@@ -91,7 +91,10 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
             throw error as? ConversationError ?? ConversationError.connectionFailed(error)
         }
 
-        return StartupResult(agentId: auth.agentId, metrics: metrics)
+        return ConversationStartResult(
+            callInfo: CallInfo(agentId: auth.agentId),
+            metrics: metrics
+        )
     }
 
     func disconnect() async {

--- a/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
+++ b/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
@@ -64,13 +64,13 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
 
         onStartupStateChange(.resolvingToken)
         if let tokenError {
-            throw StartupFailure.token(tokenError, metrics)
+            throw tokenError
         }
 
         onStartupStateChange(.connectingRoom)
         if shouldFailConnection {
             errorHandler?(connectionError)
-            throw StartupFailure.room(connectionError as? ConversationError ?? .connectionFailed(connectionError), metrics)
+            throw connectionError as? ConversationError ?? .connectionFailed(connectionError)
         }
         room = Room()
 
@@ -81,16 +81,15 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
             onStartupStateChange(.agentReady(ConversationAgentReadyReport(elapsed: elapsed)))
         case let .timedOut(elapsed):
             metrics.agentReady = elapsed
-            throw StartupFailure.agentTimeout(metrics)
+            throw ConversationError.agentTimeout
         }
 
-        onStartupStateChange(.sendingConversationInit(attempt: 1))
+        onStartupStateChange(.sendingConversationInit)
         do {
             try await send(event: .conversationInit(ConversationInitEvent(config: config)))
         } catch {
-            throw StartupFailure.conversationInit(error as? ConversationError ?? .connectionFailed(error), metrics)
+            throw error as? ConversationError ?? ConversationError.connectionFailed(error)
         }
-        metrics.conversationInitAttempts = 1
 
         return StartupResult(agentId: auth.agentId, metrics: metrics)
     }

--- a/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
+++ b/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
@@ -41,6 +41,7 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
     private(set) var lastNetworkConfiguration: WebRTCConfiguration = .default
     private(set) var lastWaitTimeout: TimeInterval = 0
     private(set) var publishedPayloads: [Data] = []
+    private var startupStateChange: ((ConversationStartupState) -> Void)?
 
     private var waitContinuation: CheckedContinuation<AgentReadyWaitResult, Never>?
     private var pendingWaitResult: AgentReadyWaitResult?
@@ -58,6 +59,7 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
         config: ConversationConfig,
         onStartupStateChange: @escaping (ConversationStartupState) -> Void
     ) async throws -> ConversationStartResult {
+        startupStateChange = onStartupStateChange
         connectCallCount += 1
         lastNetworkConfiguration = config.networkConfiguration
         var metrics = ConversationStartupMetrics()
@@ -95,6 +97,10 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
             callInfo: CallInfo(agentId: auth.agentId),
             metrics: metrics
         )
+    }
+
+    func deliverStartupState(_ state: ConversationStartupState) {
+        startupStateChange?(state)
     }
 
     func disconnect() async {

--- a/Tests/ElevenLabsTests/Mocks/MockWebSocketConnectionManager.swift
+++ b/Tests/ElevenLabsTests/Mocks/MockWebSocketConnectionManager.swift
@@ -20,7 +20,7 @@ final class MockWebSocketConnectionManager: WebSocketConnectionManaging {
         auth: ConversationCredentials,
         config: ConversationConfig,
         onStartupStateChange: @escaping (ConversationStartupState) -> Void
-    ) async throws -> StartupResult {
+    ) async throws -> ConversationStartResult {
         connectCallCount += 1
         let startTime = Date()
         var metrics = ConversationStartupMetrics()
@@ -53,7 +53,10 @@ final class MockWebSocketConnectionManager: WebSocketConnectionManaging {
         }
 
         metrics.total = Date().timeIntervalSince(startTime)
-        return StartupResult(agentId: auth.agentId, metrics: metrics)
+        return ConversationStartResult(
+            callInfo: CallInfo(agentId: auth.agentId),
+            metrics: metrics
+        )
     }
 
     func disconnect() async {

--- a/Tests/ElevenLabsTests/Mocks/MockWebSocketConnectionManager.swift
+++ b/Tests/ElevenLabsTests/Mocks/MockWebSocketConnectionManager.swift
@@ -15,7 +15,12 @@ final class MockWebSocketConnectionManager: WebSocketConnectionManaging {
     private(set) var sentPayloads: [Data] = []
     private(set) var isConnected = false
 
-    func connect(auth: ConversationCredentials, config: ConversationConfig) async throws -> StartupResult {
+    @MainActor
+    func connect(
+        auth: ConversationCredentials,
+        config: ConversationConfig,
+        onStartupStateChange: @escaping (ConversationStartupState) -> Void
+    ) async throws -> StartupResult {
         connectCallCount += 1
         let startTime = Date()
         var metrics = ConversationStartupMetrics()
@@ -25,18 +30,18 @@ final class MockWebSocketConnectionManager: WebSocketConnectionManaging {
         } catch {
             metrics.total = Date().timeIntervalSince(startTime)
             let convError = error as? ConversationError ?? .authenticationFailed(error.localizedDescription)
-            throw StartupFailure.token(convError, metrics)
+            throw convError
         }
 
         if let connectError {
             errorHandler?(connectError)
             metrics.total = Date().timeIntervalSince(startTime)
-            let convError = connectError as? ConversationError ?? .connectionFailed(connectError)
-            throw StartupFailure.conversationInit(convError, metrics)
+            throw connectError as? ConversationError ?? ConversationError.connectionFailed(connectError)
         }
 
         isConnected = true
 
+        onStartupStateChange(.sendingConversationInit)
         do {
             let initEvent = ConversationInitEvent(config: config)
             try await send(data: EventSerializer.serializeOutgoingEvent(.conversationInit(initEvent)))
@@ -44,11 +49,9 @@ final class MockWebSocketConnectionManager: WebSocketConnectionManaging {
             throw CancellationError()
         } catch {
             metrics.total = Date().timeIntervalSince(startTime)
-            let convError = error as? ConversationError ?? .connectionFailed(error)
-            throw StartupFailure.conversationInit(convError, metrics)
+            throw error as? ConversationError ?? ConversationError.connectionFailed(error)
         }
 
-        metrics.conversationInitAttempts = 1
         metrics.total = Date().timeIntervalSince(startTime)
         return StartupResult(agentId: auth.agentId, metrics: metrics)
     }

--- a/Tests/ElevenLabsTests/StartupPerformanceTest.swift
+++ b/Tests/ElevenLabsTests/StartupPerformanceTest.swift
@@ -64,12 +64,12 @@ final class StartupPerformanceTest: XCTestCase {
         switch conversation.state {
         case .idle:
             print("  [\(String(format: "%.3f", elapsed))s] State: idle")
-        case .connecting:
-            print("  [\(String(format: "%.3f", elapsed))s] State: connecting")
-        case let .connected(info):
+        case let .connecting(stage):
+            print("  [\(String(format: "%.3f", elapsed))s] State: connecting (\(stage))")
+        case let .connected(info, _):
             hasConnected = true
             print("  [\(String(format: "%.3f", elapsed))s] State: connected (agent: \(info.agentId))")
-            print("  🎯 ACTIVE STATE REACHED in \(String(format: "%.3f", elapsed))s")
+            print("  🎯 CONNECTED STATE REACHED in \(String(format: "%.3f", elapsed))s")
         case let .ended(reason):
             print("  [\(String(format: "%.3f", elapsed))s] State: ended (reason: \(reason))")
         case let .error(error):

--- a/Tests/ElevenLabsTests/StartupPerformanceTest.swift
+++ b/Tests/ElevenLabsTests/StartupPerformanceTest.swift
@@ -66,7 +66,7 @@ final class StartupPerformanceTest: XCTestCase {
             print("  [\(String(format: "%.3f", elapsed))s] State: idle")
         case let .connecting(stage):
             print("  [\(String(format: "%.3f", elapsed))s] State: connecting (\(stage))")
-        case let .connected(info, _):
+        case let .connected(info):
             hasConnected = true
             print("  [\(String(format: "%.3f", elapsed))s] State: connected (agent: \(info.agentId))")
             print("  🎯 CONNECTED STATE REACHED in \(String(format: "%.3f", elapsed))s")

--- a/Tests/ElevenLabsTests/TestSupport.swift
+++ b/Tests/ElevenLabsTests/TestSupport.swift
@@ -51,19 +51,6 @@ extension XCTestCase {
         return await recorder.last()
     }
 
-    /// Waits until the mock's `onEventReceived` handler is installed.
-    func waitForEventHandlerInstalled(
-        on mock: MockWebRTCConnectionManager,
-        timeout: TimeInterval = 1.0
-    ) async {
-        let done = expectation(description: "event handler installed")
-        Task {
-            await mock.waitForEventHandlerInstalled()
-            done.fulfill()
-        }
-        await fulfillment(of: [done], timeout: timeout)
-    }
-
     func XCTAssertThrowsErrorAsync(
         _ expression: () async throws -> some Sendable,
         _ message: @autoclosure () -> String = "",

--- a/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
+++ b/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
@@ -27,7 +27,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
     // MARK: - Tool Call Tests
 
     func testToolCallLifecycle() async throws {
-        try await conversation.startConversation(auth: .publicAgent(id: "test"))
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test"))
 
         // 1. Receive a tool call
         let toolCall = try ClientToolCallEvent(
@@ -64,7 +64,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
             let condition: String
         }
 
-        try await conversation.startConversation(auth: .publicAgent(id: "test"))
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test"))
 
         try await conversation.sendToolResult(
             for: "call_42",
@@ -84,7 +84,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
     // MARK: - Streaming Message Tests
 
     func testAgentStreamingMessages() async throws {
-        try await conversation.startConversation(auth: .publicAgent(id: "test"))
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test"))
 
         // 1. Start streaming
         mockWebRTCConnectionManager.deliver(.agentChatResponsePart(
@@ -118,7 +118,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
     // MARK: - End Call Logic
 
     func testAutomaticEndCallHandling() async throws {
-        try await conversation.startConversation(auth: .publicAgent(id: "test"))
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test"))
 
         mockWebRTCConnectionManager.deliver(.agentToolResponse(AgentToolResponseEvent(
             toolName: "end_call", toolCallId: "id", toolType: "action", isError: false, eventId: 1
@@ -131,7 +131,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
     // MARK: - Concurrency & Responsiveness
 
     func testStateTransitionsImmediatelyToConnecting() async throws {
-        try await conversation.startConversation(auth: .publicAgent(id: "old-agent"))
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "old-agent"))
         await conversation.endConversation()
 
         // Hold agent-ready so we can observe `.connecting` before startup finishes.
@@ -155,7 +155,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
     // MARK: - Audio Alignment
 
     func testAudioAlignmentUpdatesProperty() async throws {
-        try await conversation.startConversation(auth: .publicAgent(id: "test"))
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test"))
 
         let alignment = AudioAlignment(
             chars: ["H", "e", "l", "l", "o"],
@@ -169,7 +169,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
     }
 
     func testEndConversationClearsLatestAudioState() async throws {
-        try await conversation.startConversation(auth: .publicAgent(id: "test"))
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test"))
 
         let alignment = AudioAlignment(chars: ["H"], charStartTimesMs: [0], charDurationsMs: [100])
         mockWebRTCConnectionManager.deliver(.audio(AudioEvent(audioBase64: "base64", eventId: 1, alignment: alignment)))

--- a/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
+++ b/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
@@ -140,7 +140,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
             _ = try await conversation.startConversation(auth: .publicAgent(id: "new-agent"))
         }
 
-        await waitForEventHandlerInstalled(on: mockWebRTCConnectionManager)
+        await mockWebRTCConnectionManager.waitForEventHandlerInstalled()
         XCTAssertTrue(conversation.state.isConnecting, "Should be connecting immediately, even if disconnect() is slow")
 
         mockWebRTCConnectionManager.succeedAgentReady()

--- a/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
+++ b/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
@@ -140,13 +140,16 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
             try await conversation.startConversation(auth: .publicAgent(id: "new-agent"))
         }
 
-        await waitForPublished(conversation.$state) { $0 == .connecting }
-        XCTAssertEqual(conversation.state, .connecting, "Should be connecting immediately, even if disconnect() is slow")
+        await waitForEventHandlerInstalled(on: mockWebRTCConnectionManager)
+        XCTAssertTrue(conversation.state.isConnecting, "Should be connecting immediately, even if disconnect() is slow")
 
         mockWebRTCConnectionManager.succeedAgentReady()
         try await startTask.value
 
-        XCTAssertEqual(conversation.state, .connected(CallInfo(agentId: "new-agent")))
+        guard case let .connected(info, _) = conversation.state else {
+            return XCTFail("Expected connected state")
+        }
+        XCTAssertEqual(info.agentId, "new-agent")
     }
 
     // MARK: - Audio Alignment

--- a/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
+++ b/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
@@ -137,7 +137,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
         // Hold agent-ready so we can observe `.connecting` before startup finishes.
         mockWebRTCConnectionManager.autoSucceedAgentReady = false
         let startTask = Task {
-            try await conversation.startConversation(auth: .publicAgent(id: "new-agent"))
+            _ = try await conversation.startConversation(auth: .publicAgent(id: "new-agent"))
         }
 
         await waitForEventHandlerInstalled(on: mockWebRTCConnectionManager)

--- a/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
+++ b/Tests/ElevenLabsTests/Unit/BusinessLogicTests.swift
@@ -146,7 +146,7 @@ final class ElevenLabsBusinessLogicTests: XCTestCase {
         mockWebRTCConnectionManager.succeedAgentReady()
         try await startTask.value
 
-        guard case let .connected(info, _) = conversation.state else {
+        guard case let .connected(info) = conversation.state else {
             return XCTFail("Expected connected state")
         }
         XCTAssertEqual(info.agentId, "new-agent")

--- a/Tests/ElevenLabsTests/Unit/ConversationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationTests.swift
@@ -63,7 +63,7 @@ final class ConversationTests: XCTestCase {
     }
 
     func testStartConversationConfiguresIncomingEventHandler() async throws {
-        try await conversation.startConversation(
+        _ = try await conversation.startConversation(
             auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
             config: makeConfig()
         )
@@ -92,7 +92,7 @@ final class ConversationTests: XCTestCase {
 
         let startTask = Task {
             guard let conversation = self.conversation else { return }
-            try await conversation.startConversation(
+            _ = try await conversation.startConversation(
                 auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
                 config: makeConfig()
             )
@@ -126,7 +126,7 @@ final class ConversationTests: XCTestCase {
     }
 
     func testStaleProtocolDataHandlerDoesNotMutateEndedConversation() async throws {
-        try await conversation.startConversation(
+        _ = try await conversation.startConversation(
             auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
             config: makeConfig()
         )
@@ -145,7 +145,7 @@ final class ConversationTests: XCTestCase {
     func testStartConversationConfiguresRoomObservationHandlers() async throws {
         mockWebRTCConnectionManager.isMicrophoneMuted = false
 
-        try await conversation.startConversation(
+        _ = try await conversation.startConversation(
             auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
             config: makeConfig()
         )
@@ -172,7 +172,7 @@ final class ConversationTests: XCTestCase {
             }
         }
 
-        try await conversation.startConversation(
+        _ = try await conversation.startConversation(
             auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
             config: config
         )
@@ -209,7 +209,7 @@ final class ConversationTests: XCTestCase {
     }
 
     func testTextOnlyStartDisconnectsPreviousActiveManagerBeforeSwitchingTransports() async throws {
-        try await conversation.startConversation(auth: .publicAgent(id: "test-agent-id"), config: makeConfig())
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test-agent-id"), config: makeConfig())
         await conversation.endConversation()
 
         // Re-arm stale handlers so the transport switch has something to clear.
@@ -221,7 +221,7 @@ final class ConversationTests: XCTestCase {
             config.conversationOverrides = ConversationOverrides(textOnly: true)
         })
 
-        try await conversation.startConversation(
+        _ = try await conversation.startConversation(
             auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
             config: config
         )
@@ -242,7 +242,7 @@ final class ConversationTests: XCTestCase {
             config.conversationOverrides = ConversationOverrides(textOnly: true)
         })
 
-        try await conversation.startConversation(
+        _ = try await conversation.startConversation(
             auth: .signedWebSocketURL(signedURL),
             config: config
         )
@@ -274,7 +274,7 @@ final class ConversationTests: XCTestCase {
         })
 
         do {
-            try await conversation.startConversation(
+            _ = try await conversation.startConversation(
                 auth: .conversationToken("livekit-token"),
                 config: config
             )
@@ -327,7 +327,7 @@ final class ConversationTests: XCTestCase {
     func testSetHardwareMicMutedUsesConnectionManagerAudioControl() async throws {
         mockWebRTCConnectionManager.isMicrophoneMuted = false
 
-        try await conversation.startConversation(auth: .publicAgent(id: "test-agent"), config: makeConfig())
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test-agent"), config: makeConfig())
 
         try await conversation.setHardwareMicMuted(true)
 
@@ -342,7 +342,7 @@ final class ConversationTests: XCTestCase {
             config.audioConfiguration = AudioPipelineConfiguration(microphoneMuteMode: .software())
         })
 
-        try await conversation.startConversation(auth: .publicAgent(id: "test-agent"), config: config)
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test-agent"), config: config)
 
         try await conversation.setMicMuted(true)
 
@@ -393,7 +393,7 @@ final class ConversationTests: XCTestCase {
 
         guard let conversation else { return }
         await XCTAssertThrowsErrorAsync {
-            try await conversation.startConversation(
+            _ = try await conversation.startConversation(
                 auth: .publicAgent(id: "test-agent"),
                 config: config
             )
@@ -417,7 +417,7 @@ final class ConversationTests: XCTestCase {
 
         guard let conversation else { return }
         await XCTAssertThrowsErrorAsync {
-            try await conversation.startConversation(
+            _ = try await conversation.startConversation(
                 auth: .publicAgent(id: "test-agent"),
                 config: config
             )
@@ -442,7 +442,7 @@ final class ConversationTests: XCTestCase {
 
         let startTask = Task {
             guard let conversation = self.conversation else { return }
-            try await conversation.startConversation(
+            _ = try await conversation.startConversation(
                 auth: .publicAgent(id: "test-agent"),
                 config: config
             )
@@ -480,7 +480,7 @@ final class ConversationTests: XCTestCase {
         guard let conversation else { return }
 
         await XCTAssertThrowsErrorAsync {
-            try await conversation.startConversation(
+            _ = try await conversation.startConversation(
                 auth: .publicAgent(id: "test-agent"),
                 config: config
             )
@@ -520,7 +520,7 @@ final class ConversationTests: XCTestCase {
 
         let conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: callbacks)
 
-        try await conversation.startConversation(auth: .publicAgent(id: "test"), config: makeConfig())
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test"), config: makeConfig())
 
         mockWebRTCConnectionManager.deliver(.agentResponse(AgentResponseEvent(response: "Hello", eventId: 42)))
 
@@ -544,7 +544,7 @@ final class ConversationTests: XCTestCase {
         })
 
         let conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: callbacks)
-        try await conversation.startConversation(auth: .publicAgent(id: "test"), config: makeConfig())
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test"), config: makeConfig())
 
         mockWebRTCConnectionManager.deliver(.vadScore(VadScoreEvent(vadScore: 0.87)))
 
@@ -561,7 +561,7 @@ final class ConversationTests: XCTestCase {
         })
 
         let conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: callbacks)
-        try await conversation.startConversation(auth: .publicAgent(id: "test"), config: makeConfig())
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test"), config: makeConfig())
 
         mockWebRTCConnectionManager.deliver(.agentToolResponse(AgentToolResponseEvent(
             toolName: "lookup_weather", toolCallId: "id", toolType: "action", isError: false, eventId: 10
@@ -585,7 +585,7 @@ final class ConversationTests: XCTestCase {
         })
 
         let conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: callbacks)
-        try await conversation.startConversation(auth: .publicAgent(id: "test"), config: makeConfig())
+        _ = try await conversation.startConversation(auth: .publicAgent(id: "test"), config: makeConfig())
 
         mockWebRTCConnectionManager.deliver(.interruption(InterruptionEvent(eventId: 7)))
 
@@ -653,7 +653,7 @@ final class ConversationTests: XCTestCase {
         })
         let conversation = Conversation(dependencyProvider: dependencyProvider, config: config, callbacks: callbacks)
 
-        try await conversation.startConversation(
+        _ = try await conversation.startConversation(
             auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
             config: config
         )

--- a/Tests/ElevenLabsTests/Unit/ConversationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationTests.swift
@@ -430,6 +430,9 @@ final class ConversationTests: XCTestCase {
         }
 
         XCTAssertEqual(conversationError, .connectionFailed("Mock connection failed"))
+        mockWebRTCConnectionManager.deliverStartupState(.waitingForAgent(timeout: 1))
+        XCTAssertEqual(conversation.state, .error(conversationError))
+
         let errorsAfterConnectionFailure = await waitForValues(capturedErrors, count: 1)
         XCTAssertEqual(errorsAfterConnectionFailure, [.connectionFailed("Mock connection failed")])
     }

--- a/Tests/ElevenLabsTests/Unit/ConversationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationTests.swift
@@ -41,21 +41,23 @@ final class ConversationTests: XCTestCase {
         XCTAssertTrue(conversation.messages.isEmpty)
     }
 
-    func testStartConversationSuccessUpdatesStartupState() async throws {
+    func testStartConversationSuccessReturnsResult() async throws {
         let config = makeConfig()
         let conversation = Conversation(dependencyProvider: dependencyProvider, config: config, callbacks: makeCallbacks())
 
-        try await conversation.startConversation(
+        let result = try await conversation.startConversation(
             auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
             config: config
         )
 
         XCTAssertEqual(mockWebRTCConnectionManager.connectCallCount, 1)
         XCTAssertFalse(mockWebRTCConnectionManager.publishedPayloads.isEmpty)
-        guard case let .connected(callInfo, _) = conversation.state else {
+        guard case let .connected(callInfo) = conversation.state else {
             return XCTFail("Expected connected state")
         }
         XCTAssertEqual(callInfo.agentId, "test-agent-id")
+        XCTAssertEqual(result.callInfo, callInfo)
+        XCTAssertEqual(result.metrics.agentReady, 0)
         let errorsAfterSuccess = await capturedErrors.values()
         XCTAssertTrue(errorsAfterSuccess.isEmpty)
     }
@@ -249,7 +251,7 @@ final class ConversationTests: XCTestCase {
         XCTAssertEqual(mockWebSocketConnectionManager.connectCallCount, 1)
         XCTAssertEqual(mockWebSocketConnectionManager.lastConnectedURL?.absoluteString, signedURL)
         XCTAssertFalse(mockWebSocketConnectionManager.sentPayloads.isEmpty)
-        guard case let .connected(info, _) = conversation.state else {
+        guard case let .connected(info) = conversation.state else {
             return XCTFail("Expected connected state")
         }
         XCTAssertEqual(info.agentId, "agent-private")
@@ -625,7 +627,7 @@ final class ConversationTests: XCTestCase {
     func testConversationStateEnum() {
         let idleState: ConversationState = .idle
         let connectingState: ConversationState = .connecting(.preparing)
-        let connectedState: ConversationState = .connected(CallInfo(agentId: "test"), .init())
+        let connectedState: ConversationState = .connected(CallInfo(agentId: "test"))
 
         XCTAssertNotEqual(idleState, connectingState)
         XCTAssertNotEqual(connectingState, connectedState)

--- a/Tests/ElevenLabsTests/Unit/ConversationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationTests.swift
@@ -42,32 +42,20 @@ final class ConversationTests: XCTestCase {
     }
 
     func testStartConversationSuccessUpdatesStartupState() async throws {
-        let stateExpectation = expectation(description: "startup becomes connected")
-
         let config = makeConfig()
-        let callbacks = makeCallbacks(onStartupStateChange: { state in
-            if case .connected = state {
-                stateExpectation.fulfill()
-            }
-        })
-        let conversation = Conversation(dependencyProvider: dependencyProvider, config: config, callbacks: callbacks)
+        let conversation = Conversation(dependencyProvider: dependencyProvider, config: config, callbacks: makeCallbacks())
 
         try await conversation.startConversation(
             auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
             config: config
         )
 
-        await fulfillment(of: [stateExpectation], timeout: 1.0)
-
         XCTAssertEqual(mockWebRTCConnectionManager.connectCallCount, 1)
         XCTAssertFalse(mockWebRTCConnectionManager.publishedPayloads.isEmpty)
-        XCTAssertEqual(conversation.state, ConversationState.connected(.init(agentId: "test-agent-id")))
-        guard case let .connected(callInfo, metrics) = conversation.startupState else {
-            return XCTFail("Expected connected startup state")
+        guard case let .connected(callInfo, _) = conversation.state else {
+            return XCTFail("Expected connected state")
         }
         XCTAssertEqual(callInfo.agentId, "test-agent-id")
-        XCTAssertEqual(metrics.conversationInitAttempts, 1)
-        XCTAssertEqual(conversation.startupMetrics?.total, metrics.total)
         let errorsAfterSuccess = await capturedErrors.values()
         XCTAssertTrue(errorsAfterSuccess.isEmpty)
     }
@@ -170,15 +158,26 @@ final class ConversationTests: XCTestCase {
     }
 
     func testStartTextOnlyPublicAgentUsesWebSocketConnectionManager() async throws {
+        let startupStages = ValueRecorder<ConversationStartupState>()
         let config = makeConfig(configure: { config in
             config.conversationOverrides = ConversationOverrides(textOnly: true)
         })
+        conversation = Conversation(dependencyProvider: dependencyProvider, callbacks: makeCallbacks())
+        var cancellable: AnyCancellable?
+        cancellable = conversation.$state.sink { state in
+            if case let .connecting(stage) = state {
+                Task { await startupStages.append(stage) }
+            }
+        }
 
         try await conversation.startConversation(
             auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
             config: config
         )
+        cancellable?.cancel()
 
+        let reportedStartupStages = await waitForValues(startupStages, count: 2)
+        XCTAssertEqual(reportedStartupStages, [.preparing, .sendingConversationInit])
         XCTAssertEqual(mockWebRTCConnectionManager.connectCallCount, 0)
         XCTAssertEqual(mockWebSocketConnectionManager.connectCallCount, 1)
         XCTAssertEqual(mockWebSocketConnectionManager.lastConnectedURL?.scheme, "wss")
@@ -190,7 +189,7 @@ final class ConversationTests: XCTestCase {
         )
         XCTAssertFalse(mockWebSocketConnectionManager.sentPayloads.isEmpty)
         XCTAssertEqual(try sentEventType(from: mockWebSocketConnectionManager.sentPayloads[0]), "conversation_initiation_client_data")
-        XCTAssertEqual(conversation.state, ConversationState.connected(.init(agentId: "test-agent-id")))
+        XCTAssertTrue(conversation.state.isConnected)
 
         let payload: [String: Any] = [
             "type": "agent_response",
@@ -232,7 +231,7 @@ final class ConversationTests: XCTestCase {
         XCTAssertNil(mockWebRTCConnectionManager.onDisconnected)
         XCTAssertNil(mockWebRTCConnectionManager.onRemoteSpeakingChanged)
         XCTAssertEqual(mockWebSocketConnectionManager.connectCallCount, 1)
-        XCTAssertEqual(conversation.state, ConversationState.connected(.init(agentId: "test-agent-id")))
+        XCTAssertTrue(conversation.state.isConnected)
     }
 
     func testStartTextOnlySignedURLUsesProvidedWebSocketURL() async throws {
@@ -250,7 +249,10 @@ final class ConversationTests: XCTestCase {
         XCTAssertEqual(mockWebSocketConnectionManager.connectCallCount, 1)
         XCTAssertEqual(mockWebSocketConnectionManager.lastConnectedURL?.absoluteString, signedURL)
         XCTAssertFalse(mockWebSocketConnectionManager.sentPayloads.isEmpty)
-        XCTAssertEqual(conversation.state, ConversationState.connected(.init(agentId: "agent-private")))
+        guard case let .connected(info, _) = conversation.state else {
+            return XCTFail("Expected connected state")
+        }
+        XCTAssertEqual(info.agentId, "agent-private")
     }
 
     func testSignedWebSocketURLRejectsURLWithoutAgentId() {
@@ -397,13 +399,11 @@ final class ConversationTests: XCTestCase {
             XCTAssertEqual(error as? ConversationError, .authenticationFailed("Mock authentication failed"))
         }
 
-        guard case let .failed(.token(conversationError), metrics) = conversation.startupState else {
-            return XCTFail("Expected startup failure due to token")
+        guard case let .error(conversationError) = conversation.state else {
+            return XCTFail("Expected error state due to token failure")
         }
 
         XCTAssertEqual(conversationError, .authenticationFailed("Mock authentication failed"))
-        XCTAssertEqual(conversation.state, .idle)
-        XCTAssertEqual(conversation.startupMetrics?.tokenFetch, metrics.tokenFetch)
         let errorsAfterTokenFailure = await waitForValues(capturedErrors, count: 1)
         XCTAssertEqual(errorsAfterTokenFailure, [.authenticationFailed("Mock authentication failed")])
     }
@@ -423,13 +423,11 @@ final class ConversationTests: XCTestCase {
             XCTAssertEqual(error as? ConversationError, .connectionFailed("Mock connection failed"))
         }
 
-        guard case let .failed(.room(conversationError), metrics) = conversation.startupState else {
-            return XCTFail("Expected startup failure due to room connect")
+        guard case let .error(conversationError) = conversation.state else {
+            return XCTFail("Expected error state due to room connect failure")
         }
 
         XCTAssertEqual(conversationError, .connectionFailed("Mock connection failed"))
-        XCTAssertEqual(conversation.state, .idle)
-        XCTAssertEqual(conversation.startupMetrics?.roomConnect, metrics.roomConnect)
         let errorsAfterConnectionFailure = await waitForValues(capturedErrors, count: 1)
         XCTAssertEqual(errorsAfterConnectionFailure, [.connectionFailed("Mock connection failed")])
     }
@@ -459,10 +457,9 @@ final class ConversationTests: XCTestCase {
             XCTAssertEqual(error as? ConversationError, .agentTimeout)
         }
 
-        guard case .failed(.agentTimeout, _) = conversation.startupState else {
-            return XCTFail("Expected agent timeout failure state")
+        guard case .error(.agentTimeout) = conversation.state else {
+            return XCTFail("Expected agent timeout error state")
         }
-        XCTAssertEqual(conversation.state, .idle)
         XCTAssertTrue(conversation.isMicMuted)
         XCTAssertNil(mockWebRTCConnectionManager.room)
         XCTAssertNil(mockWebRTCConnectionManager.onDisconnected)
@@ -489,8 +486,8 @@ final class ConversationTests: XCTestCase {
             XCTAssertEqual(error as? ConversationError, .connectionFailed("Publish failed"))
         }
 
-        guard case let .failed(.conversationInit(conversationError), _) = conversation.startupState else {
-            return XCTFail("Expected conversation init failure state")
+        guard case let .error(conversationError) = conversation.state else {
+            return XCTFail("Expected conversation init error state")
         }
 
         XCTAssertEqual(conversationError, .connectionFailed("Publish failed"))
@@ -627,12 +624,14 @@ final class ConversationTests: XCTestCase {
 
     func testConversationStateEnum() {
         let idleState: ConversationState = .idle
-        let connectingState: ConversationState = .connecting
-        let connectedState: ConversationState = .connected(CallInfo(agentId: "test"))
+        let connectingState: ConversationState = .connecting(.preparing)
+        let connectedState: ConversationState = .connected(CallInfo(agentId: "test"), .init())
 
         XCTAssertNotEqual(idleState, connectingState)
         XCTAssertNotEqual(connectingState, connectedState)
         XCTAssertNotEqual(idleState, connectedState)
+        XCTAssertTrue(connectingState.isConnecting)
+        XCTAssertTrue(connectedState.isConnected)
     }
 
     func testFeedbackTypeEnum() {
@@ -656,7 +655,7 @@ final class ConversationTests: XCTestCase {
             auth: ConversationCredentials.publicAgent(id: "test-agent-id"),
             config: config
         )
-        XCTAssertEqual(conversation.state, ConversationState.connected(.init(agentId: "test-agent-id")))
+        XCTAssertTrue(conversation.state.isConnected)
         let disconnectsBefore = mockWebRTCConnectionManager.disconnectCallCount
 
         await mockWebRTCConnectionManager.onDisconnected?()
@@ -684,10 +683,9 @@ extension ConversationTests {
     }
 
     private func makeCallbacks(
-        onStartupStateChange: (@Sendable (ConversationStartupState) -> Void)? = nil,
         configure: ((inout ConversationCallbacks) -> Void)? = nil
     ) -> ConversationCallbacks {
-        var callbacks = ConversationCallbacks(onStartupStateChange: onStartupStateChange)
+        var callbacks = ConversationCallbacks()
 
         callbacks.onError = { [capturedErrors] error in
             Task { await capturedErrors.append(error) }

--- a/Tests/ElevenLabsTests/Unit/ConversationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationTests.swift
@@ -98,7 +98,7 @@ final class ConversationTests: XCTestCase {
             )
         }
 
-        await waitForEventHandlerInstalled(on: mockWebRTCConnectionManager)
+        await mockWebRTCConnectionManager.waitForEventHandlerInstalled()
 
         guard mockWebRTCConnectionManager.onEventReceived != nil else {
             mockWebRTCConnectionManager.succeedAgentReady()
@@ -439,25 +439,16 @@ final class ConversationTests: XCTestCase {
 
     func testStartConversationAgentTimeoutFailure() async {
         mockWebRTCConnectionManager.autoSucceedAgentReady = false
+        mockWebRTCConnectionManager.timeoutAgentReady()
 
         let startupConfig = ConversationStartupConfiguration(agentReadyTimeout: 0.05)
         let config = makeConfig(startupConfiguration: startupConfig)
 
-        let startTask = Task {
-            guard let conversation = self.conversation else { return }
+        await XCTAssertThrowsErrorAsync {
             _ = try await conversation.startConversation(
                 auth: .publicAgent(id: "test-agent"),
                 config: config
             )
-        }
-
-        await waitForEventHandlerInstalled(on: mockWebRTCConnectionManager)
-        try? await conversation.setMicMuted(false)
-        XCTAssertFalse(conversation.isMicMuted)
-        mockWebRTCConnectionManager.timeoutAgentReady()
-
-        await XCTAssertThrowsErrorAsync {
-            try await startTask.value
         } errorHandler: { error in
             XCTAssertEqual(error as? ConversationError, .agentTimeout)
         }

--- a/Tests/ElevenLabsTests/Unit/ErrorHandlingIntegrationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ErrorHandlingIntegrationTests.swift
@@ -116,7 +116,7 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
         self.conversation = conversation
 
         do {
-            try await conversation.startConversation(
+            let result = try await conversation.startConversation(
                 auth: ConversationCredentials.publicAgent(id: testAgentId),
                 config: config
             )
@@ -140,13 +140,11 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
                 print("  \(index + 1). \(state)")
             }
 
-            if case let .connected(_, metrics) = conversation.state {
-                print("\n⏱️ Startup metrics:")
-                print("  Total: \(String(format: "%.3f", metrics.total ?? 0))s")
-                print("  Token fetch: \(String(format: "%.3f", metrics.tokenFetch ?? 0))s")
-                print("  Room connect: \(String(format: "%.3f", metrics.roomConnect ?? 0))s")
-                print("  Agent ready: \(String(format: "%.3f", metrics.agentReady ?? 0))s")
-            }
+            print("\n⏱️ Startup metrics:")
+            print("  Total: \(String(format: "%.3f", result.metrics.total ?? 0))s")
+            print("  Token fetch: \(String(format: "%.3f", result.metrics.tokenFetch ?? 0))s")
+            print("  Room connect: \(String(format: "%.3f", result.metrics.roomConnect ?? 0))s")
+            print("  Agent ready: \(String(format: "%.3f", result.metrics.agentReady ?? 0))s")
 
             // Clean disconnect
             await conversation.endConversation()

--- a/Tests/ElevenLabsTests/Unit/ErrorHandlingIntegrationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ErrorHandlingIntegrationTests.swift
@@ -1,4 +1,5 @@
 // swiftlint:disable file_length type_body_length function_body_length
+import Combine
 @testable import ElevenLabs
 import XCTest
 
@@ -37,10 +38,6 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
 
         let config = ConversationConfig()
         let callbacks = ConversationCallbacks(
-            onStartupStateChange: { state in
-                print("📊 Startup state: \(state)")
-                Task { await collector.addState(state) }
-            },
             onError: { error in
                 print("✅ onError callback received: \(error)")
                 Task { await collector.addError(error) }
@@ -105,10 +102,6 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
                 print("✅ Agent ready!")
                 readyExpectation.fulfill()
             },
-            onStartupStateChange: { state in
-                print("📊 Startup state: \(state)")
-                Task { await collector.addState(state) }
-            },
             onError: { error in
                 print("❌ Unexpected error in success test: \(error)")
                 Task { await collector.addError(error) }
@@ -147,13 +140,12 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
                 print("  \(index + 1). \(state)")
             }
 
-            if case let .connected(_, metrics) = conversation.startupState {
+            if case let .connected(_, metrics) = conversation.state {
                 print("\n⏱️ Startup metrics:")
                 print("  Total: \(String(format: "%.3f", metrics.total ?? 0))s")
                 print("  Token fetch: \(String(format: "%.3f", metrics.tokenFetch ?? 0))s")
                 print("  Room connect: \(String(format: "%.3f", metrics.roomConnect ?? 0))s")
                 print("  Agent ready: \(String(format: "%.3f", metrics.agentReady ?? 0))s")
-                print("  Init attempts: \(metrics.conversationInitAttempts)")
             }
 
             // Clean disconnect
@@ -240,9 +232,6 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
                 networkConfiguration: networkConfig
             )
             let callbacks = ConversationCallbacks(
-                onStartupStateChange: { state in
-                    print("  📊 State: \(state)")
-                },
                 onError: { error in
                     print("  ❌ Error: \(error)")
                 }
@@ -277,23 +266,15 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
         }
     }
 
-    /// Test that startup state transitions are properly reported including failures
+    /// Test that startup stages are reported and failures land in `.error`.
     func testStartupStateTransitions() async throws {
-        let errorExpectation = expectation(description: "Should receive error state")
-        let collector = ErrorCollector()
+        let errorExpectation = expectation(description: "Should receive error callback")
 
         let config = ConversationConfig()
         let callbacks = ConversationCallbacks(
-            onStartupStateChange: { state in
-                print("📊 State transition: \(state)")
-                Task { await collector.addState(state) }
-
-                if case .failed = state {
-                    errorExpectation.fulfill()
-                }
-            },
             onError: { error in
                 print("❌ Error: \(error)")
+                errorExpectation.fulfill()
             }
         )
 
@@ -304,6 +285,14 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
         )
         self.conversation = conversation
 
+        var observedResolvingToken = false
+        var cancellable: AnyCancellable?
+        cancellable = conversation.$state.sink { state in
+            if case .connecting(.resolvingToken) = state {
+                observedResolvingToken = true
+            }
+        }
+
         // Use invalid agent to trigger failure
         do {
             try await conversation.startConversation(
@@ -313,26 +302,15 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
         } catch {
             // Expected
         }
+        cancellable?.cancel()
 
         await fulfillment(of: [errorExpectation], timeout: 5.0)
 
-        let capturedStartupStates = await collector.states
+        XCTAssertTrue(observedResolvingToken, "Should have resolvingToken stage")
 
-        print("\n📊 State transition sequence (\(capturedStartupStates.count) states):")
-        for (index, state) in capturedStartupStates.enumerated() {
-            print("  \(index + 1). \(state)")
+        guard case .error = conversation.state else {
+            return XCTFail("Expected error state after startup failure")
         }
-
-        // Verify we got expected state transitions
-        XCTAssertTrue(capturedStartupStates.contains { state in
-            if case .resolvingToken = state { return true }
-            return false
-        }, "Should have resolvingToken state")
-
-        XCTAssertTrue(capturedStartupStates.contains { state in
-            if case .failed = state { return true }
-            return false
-        }, "Should have failed state")
     }
 
     /// Test custom token provider error handling
@@ -386,9 +364,6 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
         let collector = ErrorCollector()
         let config = ConversationConfig()
         let callbacks = ConversationCallbacks(
-            onStartupStateChange: { state in
-                print("📊 State: \(state)")
-            },
             onError: { error in
                 print("❌ Network error: \(error)")
                 Task { await collector.addError(error) }
@@ -457,13 +432,6 @@ extension ErrorHandlingIntegrationTests {
             onDisconnect: { reason in
                 let timestamp = Self.formatTimestamp()
                 print("🔌 [\(timestamp)] DISCONNECTED (reason: \(reason))")
-            },
-            onStartupStateChange: { state in
-                let timestamp = Self.formatTimestamp()
-                print("📊 [\(timestamp)] STARTUP STATE: \(state)")
-                Task {
-                    await errorCollector.addState(state)
-                }
             },
             onError: { error in
                 let timestamp = Self.formatTimestamp()

--- a/Tests/ElevenLabsTests/Unit/ErrorHandlingIntegrationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ErrorHandlingIntegrationTests.swift
@@ -54,7 +54,7 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
 
         // Use an invalid agent ID to trigger an error
         do {
-            try await conversation.startConversation(
+            _ = try await conversation.startConversation(
                 auth: ConversationCredentials.publicAgent(id: "invalid_agent_id_12345"),
                 config: config
             )
@@ -186,7 +186,7 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
         )
         self.conversation = conversation
 
-        try await conversation.startConversation(
+        _ = try await conversation.startConversation(
             auth: ConversationCredentials.publicAgent(id: testAgentId),
             config: config
         )
@@ -242,7 +242,7 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
             )
 
             do {
-                try await conversation.startConversation(
+                _ = try await conversation.startConversation(
                     auth: ConversationCredentials.publicAgent(id: testAgentId),
                     config: config
                 )
@@ -293,7 +293,7 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
 
         // Use invalid agent to trigger failure
         do {
-            try await conversation.startConversation(
+            _ = try await conversation.startConversation(
                 auth: ConversationCredentials.publicAgent(id: "invalid_agent"),
                 config: config
             )
@@ -334,7 +334,7 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
 
         // Provide a token provider that throws an error
         do {
-            try await conversation.startConversation(
+            _ = try await conversation.startConversation(
                 auth: .customTokenProvider {
                     throw NSError(domain: "TestError", code: 500, userInfo: [
                         NSLocalizedDescriptionKey: "Custom token provider failed"
@@ -377,7 +377,7 @@ final class ErrorHandlingIntegrationTests: XCTestCase {
 
         // Attempt connection - may succeed or fail depending on network
         do {
-            try await conversation.startConversation(
+            _ = try await conversation.startConversation(
                 auth: ConversationCredentials.publicAgent(id: testAgentId),
                 config: config
             )
@@ -453,7 +453,7 @@ extension ErrorHandlingIntegrationTests {
         print("\n🚀 Starting connection...")
 
         do {
-            try await conversation.startConversation(
+            _ = try await conversation.startConversation(
                 auth: ConversationCredentials.publicAgent(id: testAgentId),
                 config: config
             )


### PR DESCRIPTION
## Summary

It's weird to have both `state` and `startupState` - they are 2 overlapping states and also `startupState` is only relevant when `state == .connecting`. This PR merges `startupState` into `state.connecting(statupState)` so that we have a single straightforward representation of current state. 

Changes:

- Make `Conversation.state` the single source of lifecycle state.
- Return `ConversationStartResult` (`callInfo` + `ConversationStartupMetrics`) from `Conversation.startConversation`.
- Remove the published `startupState` and `startupMetrics` properties.
- Remove `ConversationCallbacks.onStartupStateChange`; callers can observe `Conversation.$state`.
- Remove the `StartupFailure` wrapper, `ConversationStartupFailure`, and the always-`1` conversation-init attempt fields.
- Use `.preparing` as the initial stage before transport-specific startup begins.

## Testing

- `swift test`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public SDK API (state shape, return type, removed callbacks/properties) affects all integrators; connection startup and error paths are core conversation behavior.
> 
> **Overview**
> **Unifies conversation lifecycle** so `Conversation.state` is the only stream for idle → connecting → connected / ended / error. Startup progress lives in `.connecting(ConversationStartupState)` (including new `.preparing`), and failed starts set `.error(ConversationError)` instead of resetting to idle with a separate startup-failure enum.
> 
> **Public API changes:** `startConversation` now returns **`ConversationStartResult`** (`callInfo` + `ConversationStartupMetrics`). Removed `@Published` `startupState` / `startupMetrics`, **`ConversationCallbacks.onStartupStateChange`**, `StartupFailure` / `ConversationStartupFailure`, and init-retry attempt fields on metrics. WebSocket `connect` matches WebRTC with the same startup callback and result type.
> 
> **Internals:** Connection managers throw `ConversationError` directly; `Conversation` maps transport stage callbacks into `state`. Docs and tests updated for nested `.connecting(let stage)` and observing `$state` for startup UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4261d37180dbe84c16ebe40b79dae364925e52f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->