### PR TITLE
chore: remove public LiveKit audio track re-exports

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -192,20 +192,28 @@ struct AudioControlView: View {
 }
 ```
 
-### Raw Audio Tracks
+### Raw Audio Observers
 
-Access the underlying LiveKit audio tracks for advanced visualization (e.g., audio visualizers or level meters).
+Observe decoded PCM from the agent output or local microphone without taking a LiveKit dependency in app code. Prefer this over reaching for transport tracks.
 
 ```swift
-// Use these with LiveKit view components or custom processors
-if let inputTrack = conversation.inputTrack as? LocalAudioTrack {
-    // Access local microphone track
+final class SpectrumObserver: ConversationAudioObserver, @unchecked Sendable {
+    func didReceive(_ buffer: AVAudioPCMBuffer) {
+        // Time-critical path: copy what you need, then hop off this callback.
+        let copy = buffer.copy()
+        Task { @MainActor in
+            updateVisualizer(copy)
+        }
+    }
 }
 
-if let agentTrack = conversation.agentAudioTrack as? RemoteAudioTrack {
-    // Access agent's audio track
-}
+let client = ConversationClient()
+let observer = SpectrumObserver()
+client.addAgentAudioObserver(observer)
+client.addMicAudioObserver(observer)
 ```
+
+`didReceive(_:)` runs on the audio callback path (not the main actor). The buffer is borrowed and read-only.
 
 ---
 

--- a/Sources/ElevenLabs/Internal/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/Conversation.swift
@@ -29,10 +29,6 @@ final class Conversation: ObservableObject {
     /// Current MCP connection status for all integrations
     @Published var mcpConnectionStatus: MCPConnectionStatusEvent?
 
-    /// Device lists (optional to expose; keep `internal` if you don't want them public)
-    @Published var audioDevices: [AudioDevice] = []
-    @Published var selectedAudioDeviceID: String = ""
-
     var lastAgentEventId: Int?
     var lastFeedbackSubmittedEventId: Int?
 
@@ -103,17 +99,7 @@ final class Conversation: ObservableObject {
 
     private func setupAudioManager() {
         guard !config.conversationOverrides.textOnly else { return }
-        let manager = ConversationAudioManager(logger: logger)
-        manager.onDevicesChanged = { [weak self] devices in
-            self?.audioDevices = devices
-        }
-        manager.onSelectedDeviceChanged = { [weak self] deviceId in
-            self?.selectedAudioDeviceID = deviceId
-        }
-        audioManager = manager
-        // Sync initial values
-        audioDevices = manager.audioDevices
-        selectedAudioDeviceID = manager.selectedAudioDeviceID
+        audioManager = ConversationAudioManager(logger: logger)
     }
 
     private func setupAgentStateManager() {

--- a/Sources/ElevenLabs/Internal/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/Conversation.swift
@@ -76,7 +76,7 @@ final class Conversation: ObservableObject {
     /// Context for logging (e.g. agentId)
     private var activeContext: [String: String]?
 
-    /// Audio tracks for advanced use cases
+    /// Internal LiveKit tracks used to attach ``ConversationAudioObserver``s.
     var inputTrack: (any AudioTrackProtocol)? {
         activeWebRTCConnectionManager?.inputTrack
     }

--- a/Sources/ElevenLabs/Internal/Conversation/ConversationAudioManager.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/ConversationAudioManager.swift
@@ -8,8 +8,6 @@ import LiveKit
 /// Encapsulates all AudioManager interactions to keep Conversation class focused on conversation logic.
 @MainActor
 final class ConversationAudioManager {
-    private(set) var audioDevices: [AudioDevice] = []
-    private(set) var selectedAudioDeviceID: String = ""
     private(set) var softwareMuteProcessor: SoftwareMuteProcessor?
 
     private let audioManager = AudioManager.shared
@@ -17,22 +15,12 @@ final class ConversationAudioManager {
     private var audioSpeechHandlerInstalled = false
     private let logger: any Logging
 
-    /// Callback when audio devices list changes
-    var onDevicesChanged: (([AudioDevice]) -> Void)?
-
-    /// Callback when selected device changes
-    var onSelectedDeviceChanged: ((String) -> Void)?
-
     init(logger: any Logging) {
         self.logger = logger
-        audioDevices = audioManager.inputDevices
-        selectedAudioDeviceID = audioManager.inputDevice.deviceId
         setupInitialConfiguration()
     }
 
     deinit {
-        // Reset callbacks directly since we can't call MainActor methods from deinit
-        audioManager.onDeviceUpdate = nil
         if audioSpeechHandlerInstalled {
             audioManager.onMutedSpeechActivity = previousSpeechActivityHandler
         }
@@ -94,17 +82,6 @@ final class ConversationAudioManager {
                 try await audioManager.setRecordingAlwaysPreparedMode(true)
             } catch {
                 logger.warning("Failed to set recording always prepared mode", context: ["error": "\(error)"])
-            }
-        }
-
-        // Setup device change observer
-        audioManager.onDeviceUpdate = { [weak self] _ in
-            Task { @MainActor in
-                guard let self else { return }
-                self.audioDevices = self.audioManager.inputDevices
-                self.selectedAudioDeviceID = self.audioManager.defaultInputDevice.deviceId
-                self.onDevicesChanged?(self.audioDevices)
-                self.onSelectedDeviceChanged?(self.selectedAudioDeviceID)
             }
         }
     }

--- a/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
+++ b/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs.swift
@@ -1,5 +1,4 @@
 import Foundation
-import LiveKit
 
 // Main namespace & entry point for the ElevenLabs Conversational AI SDK.
 //
@@ -31,13 +30,6 @@ public enum ElevenLabs {
     public static func configure(_ configuration: Configuration) {
         Global.shared.configuration = configuration
     }
-
-    // MARK: - Re-exports
-
-    // Re-export audio track types for advanced audio handling
-    public typealias LocalAudioTrack = LiveKit.LocalAudioTrack
-    public typealias RemoteAudioTrack = LiveKit.RemoteAudioTrack
-    public typealias AudioTrack = LiveKit.AudioTrack
 
     // Language enum is already public and accessible as ElevenLabs.Language
 


### PR DESCRIPTION
## What

- Remove the public `ElevenLabs.LocalAudioTrack` / `RemoteAudioTrack` / `AudioTrack` LiveKit re-exports.
- Drop the unused `import LiveKit` from `ElevenLabs.swift`.
- Update Usage docs to point at `ConversationAudioObserver` instead of `conversation.inputTrack` / `agentAudioTrack`.
- Clarify that session track accessors are internal plumbing for observer attachment.

## Why

Raw audio observation is now available through `ConversationAudioObserver` without exposing LiveKit types. These re-exports were the last public LiveKit type surface in the SDK.

## Notes

- LiveKit remains an internal package dependency.
- Internal `Conversation` / connection-manager track accessors are unchanged.

## Testing

- `swiftformat 'Sources' 'Tests' --lint --strict`
- Focused startup/client/audio tests
- `swift test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API removal for apps that depended on LiveKit track types or published device lists; migration path is documented via ConversationAudioObserver.
> 
> **Overview**
> Removes the last public LiveKit type surface from the SDK by deleting `ElevenLabs` re-exports of `LocalAudioTrack`, `RemoteAudioTrack`, and `AudioTrack`, and drops the unused `import LiveKit` from the public entry module.
> 
> **Documentation** now steers integrators toward **Raw Audio Observers** (`ConversationAudioObserver` on `ConversationClient`) instead of casting `conversation.inputTrack` / `agentAudioTrack`, with notes that `didReceive(_:)` runs off the main actor on borrowed PCM buffers.
> 
> **Internal cleanup:** `Conversation` no longer publishes `audioDevices` / `selectedAudioDeviceID`, and `ConversationAudioManager` no longer mirrors input device lists or `onDeviceUpdate` wiring—session track accessors remain internal for observer attachment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2b81d5049ef7c9f2450b6a455e96be544e3dc7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->