### PR TITLE
refactor: centralize client tool result construction

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -287,13 +287,17 @@ class ConversationViewModel: ObservableObject {
                 result = "Unknown tool: \(toolCall.toolName)"
             }
             
-            try await conversation.sendToolResult(for: toolCall.toolCallId, result: result)
+            try await conversation.sendToolResult(
+                .init(toolCallId: toolCall.toolCallId, result: result)
+            )
         } catch {
             print("Tool execution failed: \(error)")
             try? await conversation.sendToolResult(
-                for: toolCall.toolCallId,
-                result: "Error: \(error.localizedDescription)",
-                isError: true
+                .init(
+                    toolCallId: toolCall.toolCallId,
+                    result: "Error: \(error.localizedDescription)",
+                    isError: true
+                )
             )
         }
     }

--- a/README.md
+++ b/README.md
@@ -122,15 +122,16 @@ private func handleToolCall(_ toolCall: ClientToolCallEvent) async {
 
         // Send the tool result back to the agent
         try await conversation?.sendToolResult(
-            for: toolCall.toolCallId,
-            result: result
+            .init(toolCallId: toolCall.toolCallId, result: result)
         )
     } catch {
         // Handle tool execution errors
         try? await conversation?.sendToolResult(
-            for: toolCall.toolCallId,
-            result: ["error": error.localizedDescription],
-            isError: true
+            .init(
+                toolCallId: toolCall.toolCallId,
+                result: ["error": error.localizedDescription],
+                isError: true
+            )
         )
     }
 }
@@ -206,7 +207,9 @@ Task {
             let result = await myAppAction(params)
 
             // 3. Send result back to the agent
-            try? await conversation.sendToolResult(for: call.toolCallId, result: result)
+            try? await conversation.sendToolResult(
+                .init(toolCallId: call.toolCallId, result: result)
+            )
         }
     }
 }

--- a/Sources/ElevenLabs/Internal/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/Conversation.swift
@@ -349,33 +349,10 @@ final class Conversation: ObservableObject {
     }
 
     /// Send the result of a client tool call back to the agent.
-    ///
-    /// The `Encodable` result is JSON-encoded before sending.
-    func sendToolResult(
-        for toolCallId: String,
-        result: some Encodable,
-        isError: Bool = false,
-        errorType: ClientToolErrorType? = nil
-    ) async throws {
-        let json = try String(decoding: JSONEncoder().encode(result), as: UTF8.self)
-        // `json` is statically a String, so this dispatches to the String overload
-        // below (a concrete match beats the generic) — not a recursive call.
-        try await sendToolResult(for: toolCallId, result: json, isError: isError, errorType: errorType)
-    }
-
-    /// Send a client tool result that is already a string (sent verbatim).
-    func sendToolResult(
-        for toolCallId: String,
-        result: String,
-        isError: Bool = false,
-        errorType: ClientToolErrorType? = nil
-    ) async throws {
+    func sendToolResult(_ result: ClientToolResultEvent) async throws {
         guard state.isConnected else { throw ConversationError.notConnected }
-        let toolResult = ClientToolResultEvent(
-            toolCallId: toolCallId, result: result, isError: isError, errorType: errorType
-        )
-        try await publish(.clientToolResult(toolResult))
-        pendingToolCalls.removeAll { $0.toolCallId == toolResult.toolCallId }
+        try await publish(.clientToolResult(result))
+        pendingToolCalls.removeAll { $0.toolCallId == result.toolCallId }
     }
 
     /// Mark a tool call as completed without sending a result (for tools that don't expect responses).

--- a/Sources/ElevenLabs/Internal/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/Conversation.swift
@@ -538,7 +538,7 @@ final class Conversation: ObservableObject {
             try? await publish(pong)
 
         case let .clientToolCall(toolCall):
-            callbacks.onUnhandledClientToolCall?(toolCall)
+            callbacks.onClientToolCall?(toolCall)
             pendingToolCalls.append(toolCall)
 
         case let .vadScore(vad):

--- a/Sources/ElevenLabs/Public/Conversation/ConversationCallbacks.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationCallbacks.swift
@@ -49,7 +49,7 @@ public struct ConversationCallbacks: Sendable {
     public var onCanSendFeedbackChange: (@Sendable (Bool) -> Void)?
 
     /// Called when a client tool call is received without a registered handler.
-    public var onUnhandledClientToolCall: (@Sendable (ClientToolCallEvent) -> Void)?
+    public var onClientToolCall: (@Sendable (ClientToolCallEvent) -> Void)?
 
     /// Called whenever the agent state changes (event-based mode only).
     public var onAgentStateChange: (@Sendable (ElevenLabs.AgentState) -> Void)?
@@ -70,7 +70,7 @@ public struct ConversationCallbacks: Sendable {
         onVadScore: (@Sendable (_ score: Double) -> Void)? = nil,
         onAudioAlignment: (@Sendable (AudioAlignment) -> Void)? = nil,
         onCanSendFeedbackChange: (@Sendable (Bool) -> Void)? = nil,
-        onUnhandledClientToolCall: (@Sendable (ClientToolCallEvent) -> Void)? = nil,
+        onClientToolCall: (@Sendable (ClientToolCallEvent) -> Void)? = nil,
         onAgentStateChange: (@Sendable (ElevenLabs.AgentState) -> Void)? = nil
     ) {
         self.onAgentReady = onAgentReady
@@ -88,7 +88,7 @@ public struct ConversationCallbacks: Sendable {
         self.onVadScore = onVadScore
         self.onAudioAlignment = onAudioAlignment
         self.onCanSendFeedbackChange = onCanSendFeedbackChange
-        self.onUnhandledClientToolCall = onUnhandledClientToolCall
+        self.onClientToolCall = onClientToolCall
         self.onAgentStateChange = onAgentStateChange
     }
 }

--- a/Sources/ElevenLabs/Public/Conversation/ConversationClient.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationClient.swift
@@ -233,29 +233,8 @@ public final class ConversationClient: ObservableObject {
     }
 
     /// Send the result of a client tool call back to the agent.
-    ///
-    /// The `Encodable` result is JSON-encoded before sending.
-    public func sendToolResult(
-        for toolCallId: String,
-        result: some Encodable,
-        isError: Bool = false,
-        errorType: ClientToolErrorType? = nil
-    ) async throws {
-        try await requireSession().sendToolResult(
-            for: toolCallId, result: result, isError: isError, errorType: errorType
-        )
-    }
-
-    /// Send a client tool result that is already a string (sent verbatim).
-    public func sendToolResult(
-        for toolCallId: String,
-        result: String,
-        isError: Bool = false,
-        errorType: ClientToolErrorType? = nil
-    ) async throws {
-        try await requireSession().sendToolResult(
-            for: toolCallId, result: result, isError: isError, errorType: errorType
-        )
+    public func sendToolResult(_ result: ClientToolResultEvent) async throws {
+        try await requireSession().sendToolResult(result)
     }
 
     /// Mark a tool call as completed without sending a result. A best-effort

--- a/Sources/ElevenLabs/Public/ElevenLabs/Events/OutgoingEvents.swift
+++ b/Sources/ElevenLabs/Public/ElevenLabs/Events/OutgoingEvents.swift
@@ -87,6 +87,22 @@ public struct ClientToolResultEvent: Sendable {
         self.isError = isError || errorType != nil
         self.errorType = errorType
     }
+
+    /// JSON-encodes `result` before creating the event.
+    public init(
+        toolCallId: String,
+        result: some Encodable,
+        isError: Bool = false,
+        errorType: ClientToolErrorType? = nil
+    ) throws {
+        let json = try String(decoding: JSONEncoder().encode(result), as: UTF8.self)
+        self.init(
+            toolCallId: toolCallId,
+            result: json,
+            isError: isError,
+            errorType: errorType
+        )
+    }
 }
 
 /// Contextual update to the conversation

--- a/Tests/ElevenLabsTests/Integration/ConversationIntegrationTests.swift
+++ b/Tests/ElevenLabsTests/Integration/ConversationIntegrationTests.swift
@@ -80,9 +80,10 @@ final class ConversationIntegrationTests: XCTestCase {
         let conv2 = conversation
         await assertThrowsConversationError(.notConnected) {
             try await conv2.sendToolResult(
-                for: "test-tool-call",
-                result: "Tool executed successfully",
-                isError: false
+                .init(
+                    toolCallId: "test-tool-call",
+                    result: "Tool executed successfully"
+                )
             )
         }
 

--- a/Tests/ElevenLabsTests/Unit/ConversationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationTests.swift
@@ -668,7 +668,9 @@ final class ConversationTests: XCTestCase {
     @MainActor
     func testSendToolResultWhenNotConnected() async {
         do {
-            try await conversation.sendToolResult(for: "tool-id", result: "result", isError: false)
+            try await conversation.sendToolResult(
+                .init(toolCallId: "tool-id", result: "result")
+            )
             XCTFail("Should throw error when not connected")
         } catch let error as ConversationError {
             XCTAssertEqual(error, .notConnected)
@@ -694,7 +696,7 @@ final class ConversationTests: XCTestCase {
         XCTAssertEqual(conversation.pendingToolCalls.first?.toolCallId, "call_123")
 
         let payloadCountBeforeResult = mockWebRTCConnectionManager.publishedPayloads.count
-        try await conversation.sendToolResult(for: "call_123", result: "success")
+        try await conversation.sendToolResult(.init(toolCallId: "call_123", result: "success"))
 
         XCTAssertTrue(conversation.pendingToolCalls.isEmpty)
         XCTAssertEqual(mockWebRTCConnectionManager.publishedPayloads.count, payloadCountBeforeResult + 1)
@@ -713,8 +715,10 @@ final class ConversationTests: XCTestCase {
         _ = try await conversation.start(auth: .publicAgent(id: "test"))
 
         try await conversation.sendToolResult(
-            for: "call_42",
-            result: Weather(temperature: 25, condition: "Sunny")
+            .init(
+                toolCallId: "call_42",
+                result: Weather(temperature: 25, condition: "Sunny")
+            )
         )
 
         let payload = try XCTUnwrap(mockWebRTCConnectionManager.publishedPayloads.last)


### PR DESCRIPTION
## Summary

- Replace the string and `Encodable` `sendToolResult` overloads with one method accepting `ClientToolResultEvent`.
- Move JSON encoding into a throwing `ClientToolResultEvent` initializer while preserving verbatim string construction.
- Update SDK examples and tool-result tests to use the event-based API.

## Test plan

- [x] `swiftformat 'Sources' 'Tests' --lint --strict`
- [x] Focused startup/client/audio/tool tests
- [x] `swift test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API for tool results and callbacks; behavior is straightforward but every integrator must update call sites. No auth or connection-path changes.
> 
> **Overview**
> **`sendToolResult`** on `Conversation` and `ConversationClient` now takes a single **`ClientToolResultEvent`** instead of separate `for` / `result` / `isError` overloads. Callers build results with **`ClientToolResultEvent.init(...)`** — string payloads stay verbatim; **`Encodable`** values are JSON-encoded via a new **throwing** initializer on the event type.
> 
> The client-tool callback is renamed from **`onUnhandledClientToolCall`** to **`onClientToolCall`**, and incoming **`clientToolCall`** events invoke that callback (not only “unhandled” cases). README, Usage docs, and tests follow the event-based pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de2010748f5948f75ae5d77f4f09a656a61b70a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->