### PR TITLE
Clean up onCanSendFeedbackChange

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -498,10 +498,6 @@ let callbacks = ConversationCallbacks(
     onAudioAlignment: { alignment in
         // Real-time word highlighting timing.
     },
-    onCanSendFeedbackChange: { canSend in
-        // Enable/disable your 'Thumbs Up/Down' buttons in the UI
-        self.showFeedbackUI = canSend
-    },
     onError: { error in
         print("A non-fatal or startup error occurred: \(error)")
     }
@@ -553,35 +549,29 @@ let config = ConversationConfig(startupConfiguration: startupConfig)
 
 ## Feedback & Context {#feedback-context}
 
-Handle feedback (like/dislike) and contextual updates to the agent.
+Feedback can be sent whenever the conversation is connected.
 
 ```swift
-// 1) Setup: react to feedback availability
-var canSendFeedback = false
-
 let callbacks = ConversationCallbacks(
     onAgentResponse: { text, eventId in
         print("Agent:", text, "(event:", eventId, ")")
-    },
-    onCanSendFeedbackChange: { can in
-        canSendFeedback = can
-        // e.g., refresh your UI
     }
 )
 
-let conversation = try await ElevenLabs.startConversation(agentId: "agent_123", callbacks: callbacks)
+let client = ConversationClient(callbacks: callbacks)
+_ = try await client.startConversation(agentId: "agent_123")
 
-// 2) Sending feedback from your UI
-func thumbsUp(latestEventId: Int) {
-    Task { try? await conversation.sendFeedback(.like, eventId: latestEventId) }
+func thumbsUp(eventId: Int) async throws {
+    guard client.state.isConnected else { return }
+    try await client.sendFeedback(.like, eventId: eventId)
 }
 
-func thumbsDown(latestEventId: Int) {
-    Task { try? await conversation.sendFeedback(.dislike, eventId: latestEventId) }
+func thumbsDown(eventId: Int) async throws {
+    guard client.state.isConnected else { return }
+    try await client.sendFeedback(.dislike, eventId: eventId)
 }
 
-// 3) Contextual updates (e.g., user preferences)
-Task { try? await conversation.updateContext("user_prefers_detailed_answers=true") }
+try await client.updateContext("user_prefers_detailed_answers=true")
 ```
 
 ---

--- a/Sources/ElevenLabs/Internal/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/Conversation.swift
@@ -29,9 +29,6 @@ final class Conversation: ObservableObject {
     /// Current MCP connection status for all integrations
     @Published var mcpConnectionStatus: MCPConnectionStatusEvent?
 
-    var lastAgentEventId: Int?
-    var lastFeedbackSubmittedEventId: Int?
-
     /// Pending mute state to apply after connection completes.
     /// Allows setting mute state during connection phase.
     private var pendingMuteState: Bool?
@@ -269,7 +266,6 @@ final class Conversation: ObservableObject {
 
         // Call user's onDisconnect callback if provided
         callbacks.onDisconnect?(disconnectReason)
-        callbacks.onCanSendFeedbackChange?(false)
     }
 
     /// Send a text message to the agent.
@@ -334,8 +330,6 @@ final class Conversation: ObservableObject {
 
         let event = OutgoingEvent.feedback(FeedbackEvent(score: score, eventId: eventId))
         try await publish(event)
-        lastFeedbackSubmittedEventId = eventId
-        callbacks.onCanSendFeedbackChange?(false)
     }
 
     /// Approve or reject an MCP tool call request from the agent.
@@ -391,7 +385,6 @@ final class Conversation: ObservableObject {
         let mode = config.conversationOverrides.textOnly ? "text-only" : "voice"
         logger.info("Starting \(mode) conversation", context: activeContext)
 
-        callbacks.onCanSendFeedbackChange?(false)
         setupAgentStateManager()
 
         connectionManager.onEventReceived = { [weak self, weak connectionManager] event in
@@ -441,10 +434,6 @@ final class Conversation: ObservableObject {
         cleanupTransientResources()
 
         pendingToolCalls.removeAll()
-
-        lastAgentEventId = nil
-        lastFeedbackSubmittedEventId = nil
-        callbacks.onCanSendFeedbackChange?(false)
     }
 
     private func cleanupTransientResources() {
@@ -493,12 +482,8 @@ final class Conversation: ObservableObject {
 
         case let .agentResponse(e):
             upsertAgentMessage(content: e.response, eventId: e.eventId)
-            lastAgentEventId = e.eventId
             agentStateManager?.processSignal(.agentResponse)
             callbacks.onAgentResponse?(e.response, e.eventId)
-            if lastFeedbackSubmittedEventId.map({ e.eventId > $0 }) ?? true {
-                callbacks.onCanSendFeedbackChange?(true)
-            }
 
         case let .agentResponseCorrection(correction):
             upsertAgentMessage(content: correction.correctedAgentResponse, eventId: correction.eventId)
@@ -527,7 +512,6 @@ final class Conversation: ObservableObject {
             speakingTimer?.cancel()
             applyStateSignal(.interruption, fallback: .listening)
             callbacks.onInterruption?(interruptionEvent.eventId)
-            callbacks.onCanSendFeedbackChange?(false)
 
         case let .conversationMetadata(metadata):
             conversationMetadata = metadata

--- a/Sources/ElevenLabs/Public/Conversation/ConversationCallbacks.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationCallbacks.swift
@@ -45,9 +45,6 @@ public struct ConversationCallbacks: Sendable {
     /// Called when audio alignment metadata is emitted.
     public var onAudioAlignment: (@Sendable (AudioAlignment) -> Void)?
 
-    /// Called when feedback availability changes.
-    public var onCanSendFeedbackChange: (@Sendable (Bool) -> Void)?
-
     /// Called when a client tool call is received without a registered handler.
     public var onClientToolCall: (@Sendable (ClientToolCallEvent) -> Void)?
 
@@ -69,7 +66,6 @@ public struct ConversationCallbacks: Sendable {
         onInterruption: (@Sendable (_ eventId: Int) -> Void)? = nil,
         onVadScore: (@Sendable (_ score: Double) -> Void)? = nil,
         onAudioAlignment: (@Sendable (AudioAlignment) -> Void)? = nil,
-        onCanSendFeedbackChange: (@Sendable (Bool) -> Void)? = nil,
         onClientToolCall: (@Sendable (ClientToolCallEvent) -> Void)? = nil,
         onAgentStateChange: (@Sendable (ElevenLabs.AgentState) -> Void)? = nil
     ) {
@@ -87,7 +83,6 @@ public struct ConversationCallbacks: Sendable {
         self.onInterruption = onInterruption
         self.onVadScore = onVadScore
         self.onAudioAlignment = onAudioAlignment
-        self.onCanSendFeedbackChange = onCanSendFeedbackChange
         self.onClientToolCall = onClientToolCall
         self.onAgentStateChange = onAgentStateChange
     }

--- a/Tests/ElevenLabsTests/Unit/ConversationEventHandlerTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationEventHandlerTests.swift
@@ -80,7 +80,6 @@ final class ConversationEventHandlerTests: XCTestCase {
         XCTAssertEqual(conversation.messages.last?.content, "I am an AI")
         XCTAssertEqual(conversation.messages.last?.role, .agent)
         XCTAssertEqual(conversation.messages.last?.eventId, 456)
-        XCTAssertEqual(conversation.lastAgentEventId, 456)
     }
 
     func testAgentResponseFinalizesStreamedMessageInsteadOfDuplicating() async {

--- a/Tests/ElevenLabsTests/Unit/ConversationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationTests.swift
@@ -557,40 +557,21 @@ final class ConversationTests: XCTestCase {
         XCTAssertEqual(errorsAfterInitFailure, [.connectionFailed("Publish failed")])
     }
 
-    func testAgentResponseCallbackTogglesFeedbackAvailability() async throws {
-        let gotResponse = expectation(description: "agent response")
-        // Feedback flips more than once (start→false, response→true, feedback→false).
-        let feedbackStates = ValueRecorder<Bool>()
-
-        let callbacks = makeCallbacks(configure: { callbacks in
-            callbacks.onAgentResponse = { text, eventId in
-                XCTAssertEqual(text, "Hello")
-                XCTAssertEqual(eventId, 42)
-                gotResponse.fulfill()
-            }
-            callbacks.onCanSendFeedbackChange = { canSend in
-                Task { await feedbackStates.append(canSend) }
-            }
-        })
-
+    func testSendFeedbackWhileConnected() async throws {
         let conversation = Conversation(
             dependencyProvider: dependencyProvider,
-            config: makeConfig(),
-            callbacks: callbacks
+            config: makeConfig()
         )
 
         _ = try await conversation.start(auth: .publicAgent(id: "test"))
 
-        mockWebRTCConnectionManager.deliver(.agentResponse(AgentResponseEvent(response: "Hello", eventId: 42)))
-
-        await fulfillment(of: [gotResponse], timeout: 1.0)
-        let initialFeedbackState = await waitForLastValue(feedbackStates) { $0 == true }
-        XCTAssertEqual(initialFeedbackState, true)
-
         try await conversation.sendFeedback(FeedbackEvent.Score.like, eventId: 42)
 
-        let updatedFeedbackState = await waitForLastValue(feedbackStates) { $0 == false }
-        XCTAssertEqual(updatedFeedbackState, false)
+        let payload = try XCTUnwrap(mockWebRTCConnectionManager.publishedPayloads.last)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: payload) as? [String: Any])
+        XCTAssertEqual(json["type"] as? String, "feedback")
+        XCTAssertEqual(json["score"] as? String, "like")
+        XCTAssertEqual(json["event_id"] as? Int, 42)
     }
 
     func testVadScoreCallbackReceivesScores() async throws {
@@ -635,34 +616,6 @@ final class ConversationTests: XCTestCase {
         )))
 
         await fulfillment(of: [gotTool], timeout: 1.0)
-    }
-
-    func testInterruptionCallbackDisablesFeedback() async throws {
-        let gotInterruption = expectation(description: "interruption")
-        let feedbackStates = ValueRecorder<Bool>()
-
-        let callbacks = makeCallbacks(configure: { callbacks in
-            callbacks.onInterruption = { id in
-                XCTAssertEqual(id, 7)
-                gotInterruption.fulfill()
-            }
-            callbacks.onCanSendFeedbackChange = { canSend in
-                Task { await feedbackStates.append(canSend) }
-            }
-        })
-
-        let conversation = Conversation(
-            dependencyProvider: dependencyProvider,
-            config: makeConfig(),
-            callbacks: callbacks
-        )
-        _ = try await conversation.start(auth: .publicAgent(id: "test"))
-
-        mockWebRTCConnectionManager.deliver(.interruption(InterruptionEvent(eventId: 7)))
-
-        await fulfillment(of: [gotInterruption], timeout: 1.0)
-        let interruptionFeedbackState = await waitForLastValue(feedbackStates) { $0 == false }
-        XCTAssertEqual(interruptionFeedbackState, false)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

Per-message feedback can be sent at any time as long as the conversation is connected. But historically it was implemented via some complex logic on the client, so that feedback was only allowed on the last message if that message doesn't have feedback yet - that's purely a client-side limitation that we don't need.

Changes:

- remove `onCanSendFeedbackChange` and its event-tracking state
- make connected conversation state the sole feedback availability signal
- update feedback documentation and coverage for connected/disconnected behavior

## Test plan
- [x] `swift test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API removal breaks apps that relied on `onCanSendFeedbackChange`; behavior change may allow feedback on older messages while connected, which is intentional but affects UI assumptions.
> 
> **Overview**
> Removes client-side **feedback gating** so apps no longer get `onCanSendFeedbackChange` or internal tracking (`lastAgentEventId`, `lastFeedbackSubmittedEventId`). Feedback is allowed for any `eventId` while the session is **connected**; `sendFeedback` still throws when not connected.
> 
> **Breaking:** `ConversationCallbacks.onCanSendFeedbackChange` is removed from the public API. UI should enable thumbs up/down based on `client.state.isConnected` (or equivalent) instead of SDK-driven toggles on agent response, interruption, disconnect, and after submit.
> 
> Docs and tests are updated: `Usage.md` shows `ConversationClient` + `guard client.state.isConnected`, and unit tests assert published feedback payloads instead of callback-driven availability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c7b74184b359aeaaef4c0937cdc48d40b2d9d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->