### PR TITLE
Update Endpoint configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,16 @@ ElevenLabs.configure(
 )
 ```
 
+### Custom Endpoints
+
+Point the HTTP API base or either WebSocket endpoint at a proxy, regional host, or staging:
+
+```swift
+let config = ConversationConfig(
+    endpoints: Endpoints(apiBase: URL(string: "https://my-proxy.example.com")!)
+)
+```
+
 ### Fine-Grained Callbacks
 
 Want to handle events without Combine? Use `ConversationCallbacks`:

--- a/Sources/ElevenLabs/Internal/Authorization/ConnectionConstants.swift
+++ b/Sources/ElevenLabs/Internal/Authorization/ConnectionConstants.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-enum ConnectionConstants {
-    /// LiveKit signaling endpoint used for voice conversations.
-    static let voiceConversationUrl = "wss://livekit.rtc.elevenlabs.io"
-    /// WebSocket endpoint used for text-only conversations.
-    static let textConversationUrl = "wss://api.elevenlabs.io/v1/convai/conversation"
-    static let tokenUrl = "https://api.elevenlabs.io/v1/convai/conversation/token"
-}

--- a/Sources/ElevenLabs/Internal/Authorization/TokenServicing.swift
+++ b/Sources/ElevenLabs/Internal/Authorization/TokenServicing.swift
@@ -1,10 +1,9 @@
 import Foundation
 
 protocol TokenServicing: Sendable {
-    /// Fetch connection details for ElevenLabs conversation
-    /// - Parameter configuration: The configuration to use for fetching connection details
-    /// - Returns: The connection details for the ElevenLabs conversation
-    func fetchConnectionDetails(configuration: ConversationCredentials) async throws -> TokenService.ConnectionDetails
+    /// Resolve the token a voice conversation authenticates with.
+    /// - Parameter credentials: The credentials to authenticate with
+    func fetchToken(for credentials: ConversationCredentials) async throws -> String
 }
 
 extension TokenService: TokenServicing {}

--- a/Sources/ElevenLabs/Internal/DI/Dependencies.swift
+++ b/Sources/ElevenLabs/Internal/DI/Dependencies.swift
@@ -14,15 +14,15 @@ final class Dependencies: ConversationDependencyProvider {
     let webRTCConnectionManager: any WebRTCConnectionManaging
     let webSocketConnectionManager: any WebSocketConnectionManaging
 
-    init() {
+    init(endpoints: Endpoints = .production) {
         let globalConfig = ElevenLabs.Global.shared.configuration
-        let tokenService = TokenService(configuration: TokenService.Configuration(
-            apiEndpoint: globalConfig.apiEndpoint?.absoluteString,
-            websocketURL: globalConfig.websocketUrl
-        ))
         let logger = SDKLogger(logLevel: globalConfig.logLevel)
         self.logger = logger
-        webRTCConnectionManager = WebRTCConnectionManager(logger: logger, tokenService: tokenService)
-        webSocketConnectionManager = WebSocketConnectionManager(logger: logger)
+        webRTCConnectionManager = WebRTCConnectionManager(
+            logger: logger,
+            tokenService: TokenService(endpoints: endpoints),
+            endpoints: endpoints
+        )
+        webSocketConnectionManager = WebSocketConnectionManager(logger: logger, endpoints: endpoints)
     }
 }

--- a/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
@@ -67,10 +67,12 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
 
     private let logger: any Logging
     private let tokenService: any TokenServicing
+    private let endpoints: Endpoints
 
-    init(logger: any Logging, tokenService: any TokenServicing) {
+    init(logger: any Logging, tokenService: any TokenServicing, endpoints: Endpoints) {
         self.logger = logger
         self.tokenService = tokenService
+        self.endpoints = endpoints
     }
 
     // MARK: – Public API
@@ -92,12 +94,12 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
         var metrics = ConversationStartupMetrics()
         logger.info("Starting conversation startup sequence", context: ["agentId": auth.agentId])
 
-        // 1. Resolve token / connection details.
+        // 1. Resolve the conversation token.
         onStartupStateChange(.resolvingToken)
-        let connectionDetails = try await runPhase(
+        let token = try await runPhase(
             timing: \.tokenFetch, metrics: &metrics, startTime: startTime
         ) {
-            try await tokenService.fetchConnectionDetails(configuration: auth)
+            try await tokenService.fetchToken(for: auth)
         }
 
         // 2. Request microphone permission (denial doesn't block startup).
@@ -110,7 +112,7 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
             timing: \.roomConnect, metrics: &metrics, startTime: startTime
         ) {
             try await connectToRoom(
-                details: connectionDetails,
+                token: token,
                 enableMic: permissionGranted,
                 throwOnMicrophoneFailure: throwOnMicFailure,
                 networkConfiguration: config.networkConfiguration,
@@ -217,12 +219,12 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
     /// used by `connect`).
     ///
     /// - Parameters:
-    ///   - details: Token-service credentials (URL + participant token).
+    ///   - token: Conversation token to authenticate the room with.
     ///   - enableMic: Whether to enable the local microphone immediately.
     ///   - throwOnMicrophoneFailure: If true, throws error when microphone setup fails.
     ///     If false, logs warning and continues.
     private func connectToRoom(
-        details: TokenService.ConnectionDetails,
+        token: String,
         enableMic: Bool,
         throwOnMicrophoneFailure: Bool,
         networkConfiguration: WebRTCConfiguration,
@@ -258,8 +260,8 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
         let connectStart = Date()
         do {
             try await room.connect(
-                url: details.serverUrl,
-                token: details.participantToken,
+                url: endpoints.voiceWebSocket.absoluteString,
+                token: token,
                 connectOptions: connectOptions
             )
             logger.info("LiveKit room.connect completed", context: ["duration": "\(Date().timeIntervalSince(connectStart))"])

--- a/Sources/ElevenLabs/Internal/Networking/WebSocketConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebSocketConnectionManager.swift
@@ -17,12 +17,14 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
 
     private let urlSession: URLSession
     private let logger: any Logging
+    private let endpoints: Endpoints
     private var task: URLSessionWebSocketTask?
     private var receiveTask: Task<Void, Never>?
     private var initiationMetadataWaiter: ConversationInitiationMetadataWaiter?
 
-    init(logger: any Logging) {
+    init(logger: any Logging, endpoints: Endpoints = .production) {
         self.logger = logger
+        self.endpoints = endpoints
         urlSession = URLSession(configuration: .default)
     }
 
@@ -46,7 +48,7 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
 
         let url: URL
         do {
-            url = try Self.url(for: auth)
+            url = try Self.websocketUrl(for: auth, endpoints: endpoints)
         } catch {
             metrics.total = Date().timeIntervalSince(startTime)
             let convError = error as? ConversationError ?? .authenticationFailed(error.localizedDescription)
@@ -147,12 +149,16 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
         }
     }
 
-    static func url(for auth: ConversationCredentials) throws -> URL {
+    static func websocketUrl(for auth: ConversationCredentials, endpoints: Endpoints) throws -> URL {
         switch auth.authSource {
         case let .publicAgentId(agentId):
-            var components = URLComponents(string: ConnectionConstants.textConversationUrl)
-            components?.queryItems = [URLQueryItem(name: "agent_id", value: agentId)]
-            guard let url = components?.url else {
+            guard var components = URLComponents(url: endpoints.textWebSocket, resolvingAgainstBaseURL: false) else {
+                throw ConversationError.authenticationFailed("Invalid conversation URL")
+            }
+            var queryItems = components.queryItems ?? []
+            queryItems.append(URLQueryItem(name: "agent_id", value: agentId))
+            components.queryItems = queryItems
+            guard let url = components.url else {
                 throw ConversationError.authenticationFailed("Invalid conversation URL")
             }
             return url

--- a/Sources/ElevenLabs/Public/Authorization/TokenService.swift
+++ b/Sources/ElevenLabs/Public/Authorization/TokenService.swift
@@ -17,29 +17,7 @@ import Foundation
 /// Service for managing ElevenLabs authentication
 /// This is designed to be stateless and SDK-friendly
 public struct TokenService: Sendable {
-    public struct ConnectionDetails: Codable, Sendable {
-        public let serverUrl: String
-        public let roomName: String
-        public let participantName: String
-        public let participantToken: String
-    }
-
-    /// Optional configuration for advanced use cases
-    public struct Configuration: Sendable {
-        /// Custom API endpoint (for testing or enterprise deployments)
-        public let apiEndpoint: String?
-        /// Custom WebSocket URL (for testing or enterprise deployments)
-        public let websocketURL: String?
-
-        public init(apiEndpoint: String? = nil, websocketURL: String? = nil) {
-            self.apiEndpoint = apiEndpoint
-            self.websocketURL = websocketURL
-        }
-
-        public static let `default` = Configuration()
-    }
-
-    private let configuration: Configuration
+    private let endpoints: Endpoints
     private let urlSession: URLSession
 
     // Development-only API key for testing private agents
@@ -48,53 +26,45 @@ public struct TokenService: Sendable {
     public let debugApiKey: String?
 
     public init(
-        configuration: Configuration = .default,
+        endpoints: Endpoints = .production,
         urlSession: URLSession = .shared,
         debugApiKey: String? = nil
     ) {
-        self.configuration = configuration
+        self.endpoints = endpoints
         self.urlSession = urlSession
         self.debugApiKey = debugApiKey
     }
     #else
     public init(
-        configuration: Configuration = .default,
+        endpoints: Endpoints = .production,
         urlSession: URLSession = .shared
     ) {
-        self.configuration = configuration
+        self.endpoints = endpoints
         self.urlSession = urlSession
     }
     #endif
 
-    /// Fetch connection details for ElevenLabs conversation.
+    /// Resolve the token a voice conversation authenticates with.
     ///
     /// Translates internal `TokenError`s into public `ConversationError`s so
     /// callers only ever deal with one error type.
-    public func fetchConnectionDetails(configuration: ConversationCredentials) async throws -> ConnectionDetails {
+    public func fetchToken(for credentials: ConversationCredentials) async throws -> String {
         do {
-            let token: String = switch configuration.authSource {
+            switch credentials.authSource {
             case let .publicAgentId(agentId):
-                try await fetchTokenFromAPI(agentId: agentId, environment: configuration.environment)
+                return try await fetchTokenFromAPI(
+                    agentId: agentId,
+                    environment: credentials.environment
+                )
             case let .conversationToken(conversationToken):
-                conversationToken
+                return conversationToken
             case .signedWebSocketURL:
                 throw ConversationError.authenticationFailed(
                     "Signed WebSocket URLs are only supported for text-only conversations."
                 )
             case let .customTokenProvider(provider):
-                try await provider()
+                return try await provider()
             }
-
-            let websocketURL = self.configuration.websocketURL ?? ConnectionConstants.voiceConversationUrl
-
-            // ElevenLabs tokens contain room name and participant identity in the JWT
-            // LiveKit will extract these automatically, so we provide empty values
-            return ConnectionDetails(
-                serverUrl: websocketURL,
-                roomName: "", // LiveKit extracts from JWT
-                participantName: "", // LiveKit extracts from JWT
-                participantToken: token
-            )
         } catch let error as ConversationError {
             throw error
         } catch let error as TokenError {
@@ -104,14 +74,18 @@ public struct TokenService: Sendable {
         }
     }
 
-    private func fetchTokenFromAPI(agentId: String, environment: String? = nil) async throws -> String {
-        // Build URL with agent ID as query parameter
-        let apiUrl = configuration.apiEndpoint ?? ConnectionConstants.tokenUrl
-
-        guard var components = URLComponents(string: apiUrl) else {
+    private func fetchTokenFromAPI(
+        agentId: String,
+        environment: String? = nil
+    ) async throws -> String {
+        guard var components = URLComponents(
+            url: endpoints.conversationToken,
+            resolvingAgainstBaseURL: false
+        ) else {
             throw TokenError.invalidURL
         }
-        var queryItems = [
+        var queryItems = components.queryItems ?? []
+        queryItems += [
             URLQueryItem(name: "agent_id", value: agentId),
             URLQueryItem(name: "source", value: "swift_sdk"),
             URLQueryItem(name: "version", value: SDKVersion.version)

--- a/Sources/ElevenLabs/Public/Conversation/ConversationClient.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationClient.swift
@@ -104,7 +104,7 @@ public final class ConversationClient: ObservableObject {
     ) async throws -> ConversationStartResult {
         let previousConversation = session
         let conversation = Conversation(
-            dependencyProvider: dependencyProvider ?? Dependencies(),
+            dependencyProvider: dependencyProvider ?? Dependencies(endpoints: config.endpoints),
             config: config,
             callbacks: callbacks,
             initialMicMuted: isMicMuted

--- a/Sources/ElevenLabs/Public/Conversation/ConversationConfig.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationConfig.swift
@@ -35,6 +35,9 @@ public struct ConversationConfig: Sendable {
     /// instead of relying on LiveKit's isSpeaking detection.
     public var agentStateConfiguration: AgentStateConfiguration?
 
+    /// Network endpoints to connect to. Override for proxies, regional hosts, or staging.
+    public var endpoints: Endpoints
+
     public init(
         agentOverrides: AgentOverrides? = nil,
         ttsOverrides: TTSOverrides? = nil,
@@ -47,7 +50,8 @@ public struct ConversationConfig: Sendable {
         startupConfiguration: ConversationStartupConfiguration = .default,
         audioConfiguration: AudioPipelineConfiguration? = nil,
         networkConfiguration: WebRTCConfiguration = .default,
-        agentStateConfiguration: AgentStateConfiguration? = nil
+        agentStateConfiguration: AgentStateConfiguration? = nil,
+        endpoints: Endpoints = .production
     ) {
         self.agentOverrides = agentOverrides
         self.ttsOverrides = ttsOverrides
@@ -61,6 +65,7 @@ public struct ConversationConfig: Sendable {
         self.audioConfiguration = audioConfiguration
         self.networkConfiguration = networkConfiguration
         self.agentStateConfiguration = agentStateConfiguration
+        self.endpoints = endpoints
     }
 }
 
@@ -112,5 +117,38 @@ public struct ConversationOverrides: Sendable {
     ) {
         self.textOnly = textOnly
         self.clientEvents = clientEvents
+    }
+}
+
+/// The network endpoints the SDK talks to. Defaults to ``production``.
+///
+/// Override for proxies, regional hosts, or staging. Credentials follow these
+/// endpoints — conversation tokens are sent to whichever `apiBase` is configured.
+public struct Endpoints: Sendable, Equatable {
+    /// Base URL for the HTTP API. Request paths are appended to it.
+    public var apiBase: URL
+    /// WebSocket endpoint for voice conversations.
+    public var voiceWebSocket: URL
+    /// WebSocket endpoint for text-only conversations.
+    public var textWebSocket: URL
+
+    public init(
+        apiBase: URL = Endpoints.production.apiBase,
+        voiceWebSocket: URL = Endpoints.production.voiceWebSocket,
+        textWebSocket: URL = Endpoints.production.textWebSocket
+    ) {
+        self.apiBase = apiBase
+        self.voiceWebSocket = voiceWebSocket
+        self.textWebSocket = textWebSocket
+    }
+
+    public static let production = Endpoints(
+        apiBase: URL(string: "https://api.elevenlabs.io")!,
+        voiceWebSocket: URL(string: "wss://livekit.rtc.elevenlabs.io")!,
+        textWebSocket: URL(string: "wss://api.elevenlabs.io/v1/convai/conversation")!
+    )
+
+    var conversationToken: URL {
+        apiBase.appendingPathComponent("v1/convai/conversation/token")
     }
 }

--- a/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs+Configuration.swift
+++ b/Sources/ElevenLabs/Public/ElevenLabs/ElevenLabs+Configuration.swift
@@ -3,19 +3,13 @@ import Foundation
 extension ElevenLabs {
     /// Global SDK configuration.
     public struct Configuration: Sendable {
-        public let apiEndpoint: URL?
-        public let websocketUrl: String?
         public let logLevel: LogLevel
         public let debugMode: Bool
 
         public init(
-            apiEndpoint: URL? = nil,
-            websocketUrl: String? = nil,
             logLevel: LogLevel = .warning,
             debugMode: Bool = false
         ) {
-            self.apiEndpoint = apiEndpoint
-            self.websocketUrl = websocketUrl
             self.logLevel = logLevel
             self.debugMode = debugMode
         }
@@ -24,14 +18,10 @@ extension ElevenLabs {
 
         /// Create a new configuration with updated values (builder pattern)
         public func with(
-            apiEndpoint: URL? = nil,
-            websocketUrl: String? = nil,
             logLevel: LogLevel? = nil,
             debugMode: Bool? = nil
         ) -> Configuration {
             Configuration(
-                apiEndpoint: apiEndpoint ?? self.apiEndpoint,
-                websocketUrl: websocketUrl ?? self.websocketUrl,
                 logLevel: logLevel ?? self.logLevel,
                 debugMode: debugMode ?? self.debugMode
             )

--- a/Tests/ElevenLabsTests/ElevenLabsTests.swift
+++ b/Tests/ElevenLabsTests/ElevenLabsTests.swift
@@ -4,7 +4,6 @@ import XCTest
 final class ElevenLabsTests: XCTestCase {
     func testConfigurationDefault() {
         let config = ElevenLabs.Configuration.default
-        XCTAssertNil(config.apiEndpoint)
         XCTAssertEqual(config.logLevel, .warning)
         XCTAssertFalse(config.debugMode)
     }
@@ -14,5 +13,6 @@ final class ElevenLabsTests: XCTestCase {
         XCTAssertNil(config.agentOverrides)
         XCTAssertNil(config.ttsOverrides)
         XCTAssertFalse(config.conversationOverrides.textOnly)
+        XCTAssertEqual(config.endpoints, .production)
     }
 }

--- a/Tests/ElevenLabsTests/Mocks/MockWebSocketConnectionManager.swift
+++ b/Tests/ElevenLabsTests/Mocks/MockWebSocketConnectionManager.swift
@@ -34,7 +34,7 @@ final class MockWebSocketConnectionManager: WebSocketConnectionManaging {
         var metrics = ConversationStartupMetrics()
 
         do {
-            lastConnectedURL = try WebSocketConnectionManager.url(for: auth)
+            lastConnectedURL = try WebSocketConnectionManager.websocketUrl(for: auth, endpoints: config.endpoints)
         } catch {
             metrics.total = Date().timeIntervalSince(startTime)
             let convError = error as? ConversationError ?? .authenticationFailed(error.localizedDescription)

--- a/Tests/ElevenLabsTests/Unit/ElevenLabsSDKTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ElevenLabsSDKTests.swift
@@ -10,19 +10,16 @@ final class ElevenLabsSDKTests: XCTestCase {
     func testDefaultConfiguration() {
         let config = ElevenLabs.Configuration.default
 
-        XCTAssertNil(config.apiEndpoint)
         XCTAssertEqual(config.logLevel, .warning)
         XCTAssertFalse(config.debugMode)
     }
 
     func testCustomConfiguration() {
         let config = ElevenLabs.Configuration(
-            apiEndpoint: URL(string: "https://custom.api.com"),
             logLevel: .debug,
             debugMode: true
         )
 
-        XCTAssertEqual(config.apiEndpoint, URL(string: "https://custom.api.com"))
         XCTAssertEqual(config.logLevel, .debug)
         XCTAssertTrue(config.debugMode)
     }
@@ -30,15 +27,11 @@ final class ElevenLabsSDKTests: XCTestCase {
     @MainActor
     func testConfigureSDK() {
         let config = ElevenLabs.Configuration(
-            apiEndpoint: URL(string: "https://test.api.com"),
             logLevel: .info,
             debugMode: false
         )
 
         ElevenLabs.configure(config)
-
-        // Verify configuration was applied (in real implementation)
-        // This would require exposing the internal configuration for testing
     }
 
     @MainActor
@@ -104,12 +97,46 @@ final class ElevenLabsSDKTests: XCTestCase {
         XCTAssertEqual(errorConfig.logLevel, .error)
     }
 
+    func testEndpointsDefaultToProduction() {
+        XCTAssertEqual(ConversationConfig().endpoints, .production)
+        XCTAssertEqual(Endpoints(), .production)
+    }
+
+    func testEndpointsOverrideIndividualHosts() throws {
+        let endpoints = try Endpoints(voiceWebSocket: XCTUnwrap(URL(string: "wss://rtc.example.com")))
+        XCTAssertEqual(endpoints.voiceWebSocket.absoluteString, "wss://rtc.example.com")
+        XCTAssertEqual(endpoints.textWebSocket, Endpoints.production.textWebSocket)
+        XCTAssertEqual(endpoints.apiBase, Endpoints.production.apiBase)
+    }
+
+    func testConversationTokenDerivesFromAPIBase() throws {
+        let endpoints = try Endpoints(apiBase: XCTUnwrap(URL(string: "https://proxy.example.com/eleven")))
+        XCTAssertEqual(
+            endpoints.conversationToken.absoluteString,
+            "https://proxy.example.com/eleven/v1/convai/conversation/token"
+        )
+        XCTAssertEqual(
+            Endpoints.production.conversationToken.absoluteString,
+            "https://api.elevenlabs.io/v1/convai/conversation/token"
+        )
+    }
+
+    func testWebsocketUrlKeepsEndpointQueryItems() throws {
+        let endpoints = try Endpoints(textWebSocket: XCTUnwrap(URL(string: "wss://proxy.example.com/ws?tenant=acme")))
+        let url = try WebSocketConnectionManager.websocketUrl(
+            for: .publicAgent(id: "agent-123"),
+            endpoints: endpoints
+        )
+        XCTAssertEqual(url.absoluteString, "wss://proxy.example.com/ws?tenant=acme&agent_id=agent-123")
+    }
+
     func testConversationConfigDefaults() {
         let config = ConversationConfig()
 
         XCTAssertNil(config.agentOverrides)
         XCTAssertNil(config.ttsOverrides)
         XCTAssertFalse(config.conversationOverrides.textOnly)
+        XCTAssertEqual(config.endpoints, .production)
     }
 
     func testAuthenticationMethods() {


### PR DESCRIPTION
## Summary

This is a step towards getting rid of global SDK config.

- Add `Endpoints` on `ConversationConfig`: an `apiBase` for HTTP calls (the conversation token URL derives from it, there will be more endpoints using it later), plus explicit voice and text WebSocket URLs
- Wire endpoints through `Dependencies` → `TokenService` / `WebSocketConnectionManager` / `WebRTCConnectionManager`
- Delete `ConnectionConstants` and remove `apiEndpoint` / `websocketUrl` from global `ElevenLabs.Configuration` (logging `configure` remains)
- Simplify the API of TokenService - return just the token instead of a unnecessary wrapper.

## Test plan
- [x] `swift test`

Stacked on #218.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API breaks for apps that customized endpoints via global `ElevenLabs.Configuration`; connection and token URLs now depend on per-session config, though production defaults match prior behavior.
> 
> **Overview**
> Moves **network targeting off global SDK config** onto **`ConversationConfig.endpoints`** via a new **`Endpoints`** type (`apiBase`, `voiceWebSocket`, `textWebSocket`, defaulting to production). Token fetch, LiveKit voice connect, and text WebSocket URLs now read from that config through **`Dependencies`**, **`TokenService`**, **`WebRTCConnectionManager`**, and **`WebSocketConnectionManager`**.
> 
> **`ElevenLabs.Configuration`** no longer exposes **`apiEndpoint`** / **`websocketUrl`** (logging **`configure`** remains). **`ConnectionConstants`** is removed; the conversation token HTTP URL is derived from **`apiBase`**.
> 
> **`TokenService`** / **`TokenServicing`** are simplified: **`fetchToken(for:)`** returns a **`String`** instead of a **`ConnectionDetails`** bundle with server URL and empty room fields. **`ConversationClient`** builds **`Dependencies(endpoints: config.endpoints)`** when starting a session.
> 
> README adds a **Custom Endpoints** example; tests cover defaults, overrides, token URL derivation, and preserving existing query items on text WebSocket URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 403fac604ef0544e45a545c9941bfa47aedb303a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



