### PR TITLE
feat: add ElevenLabsWidget with a runnable DemoApp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ xcuserdata/
 xcshareddata/
 Package.resolved
 *.bak
+DerivedData/
+*.xcuserstate

--- a/Examples/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/Examples/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -1,0 +1,281 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		E1000101000000000000A001 /* ElevenLabs in Frameworks */ = {isa = PBXBuildFile; productRef = E1000201000000000000A001 /* ElevenLabs */; };
+		E1000102000000000000A001 /* ElevenLabsWidget in Frameworks */ = {isa = PBXBuildFile; productRef = E1000202000000000000A001 /* ElevenLabsWidget */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		E1000301000000000000A001 /* DemoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		E1000401000000000000A001 /* DemoApp */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = DemoApp;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E1000501000000000000A001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1000101000000000000A001 /* ElevenLabs in Frameworks */,
+				E1000102000000000000A001 /* ElevenLabsWidget in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		E1000601000000000000A001 = {
+			isa = PBXGroup;
+			children = (
+				E1000401000000000000A001 /* DemoApp */,
+				E1000602000000000000A001 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		E1000602000000000000A001 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E1000301000000000000A001 /* DemoApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E1000701000000000000A001 /* DemoApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E1000901000000000000A001 /* Build configuration list for PBXNativeTarget "DemoApp" */;
+			buildPhases = (
+				E1000801000000000000A001 /* Sources */,
+				E1000501000000000000A001 /* Frameworks */,
+				E1000802000000000000A001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				E1000401000000000000A001 /* DemoApp */,
+			);
+			name = DemoApp;
+			packageProductDependencies = (
+				E1000201000000000000A001 /* ElevenLabs */,
+				E1000202000000000000A001 /* ElevenLabsWidget */,
+			);
+			productName = DemoApp;
+			productReference = E1000301000000000000A001 /* DemoApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E1000001000000000000A001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2640;
+				LastUpgradeCheck = 2640;
+			};
+			buildConfigurationList = E1000902000000000000A001 /* Build configuration list for PBXProject "DemoApp" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E1000601000000000000A001;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				E1000A01000000000000A001 /* XCLocalSwiftPackageReference "../.." */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = E1000602000000000000A001 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E1000701000000000000A001 /* DemoApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E1000802000000000000A001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E1000801000000000000A001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		E1000B01000000000000A001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		E1000B02000000000000A001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		E1000B03000000000000A001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "The demo uses the microphone for voice conversations.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.elevenlabs.example.DemoApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E1000B04000000000000A001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "The demo uses the microphone for voice conversations.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.elevenlabs.example.DemoApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E1000901000000000000A001 /* Build configuration list for PBXNativeTarget "DemoApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E1000B03000000000000A001 /* Debug */,
+				E1000B04000000000000A001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E1000902000000000000A001 /* Build configuration list for PBXProject "DemoApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E1000B01000000000000A001 /* Debug */,
+				E1000B02000000000000A001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		E1000A01000000000000A001 /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../..";
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		E1000201000000000000A001 /* ElevenLabs */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ElevenLabs;
+		};
+		E1000202000000000000A001 /* ElevenLabsWidget */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ElevenLabsWidget;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = E1000001000000000000A001 /* Project object */;
+}

--- a/Examples/DemoApp/DemoApp/App.swift
+++ b/Examples/DemoApp/DemoApp/App.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct DemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Examples/DemoApp/DemoApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Examples/DemoApp/DemoApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/DemoApp/DemoApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/DemoApp/DemoApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/DemoApp/DemoApp/Assets.xcassets/Contents.json
+++ b/Examples/DemoApp/DemoApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Examples/DemoApp/DemoApp/ContentView.swift
+++ b/Examples/DemoApp/DemoApp/ContentView.swift
@@ -1,0 +1,195 @@
+import ElevenLabs
+import ElevenLabsWidget
+import SwiftUI
+
+/// Minimal host for `ChatWidget`.
+struct ContentView: View {
+    /// The shapes of `WidgetConversationMode` the demo can switch between.
+    private enum Mode: String, CaseIterable, Identifiable {
+        case voiceAndText = "Voice + text"
+        case voiceOnly = "Voice only"
+        case textOnly = "Text only"
+        case either = "Either"
+
+        var id: String {
+            rawValue
+        }
+
+        var needsVoice: Bool {
+            self != .textOnly
+        }
+
+        var needsTextOnly: Bool {
+            self == .textOnly || self == .either
+        }
+    }
+
+    private enum Auth: String, CaseIterable, Identifiable {
+        case publicAgent = "Public agent"
+        case backend = "From your backend"
+
+        var id: String {
+            rawValue
+        }
+    }
+
+    @StateObject private var chat = ChatWidgetController()
+    @State private var mode: Mode = .voiceAndText
+    @State private var auth: Auth = .publicAgent
+
+    @State private var agentId = ""
+    @State private var conversationToken = ""
+    @State private var signedWebSocketURL = ""
+
+    var body: some View {
+        ZStack {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("ElevenLabs Agents")
+                    .font(.title)
+
+                Text(
+                    """
+                    This is a demo app for ElevenLabs Agents. You can either \
+                    import the widget into your app, or import the core SDK \
+                    and implement your own UI.
+                    """
+                )
+                .foregroundStyle(.secondary)
+
+                credentialsForm
+
+                if let missingCredentials {
+                    Text(missingCredentials)
+                        .foregroundStyle(.orange)
+                } else {
+                    Text("Credentials set — open the chat button to start.")
+                        .foregroundStyle(.secondary)
+                    hostControls
+                }
+
+                Spacer()
+            }
+            .padding()
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+            if missingCredentials == nil {
+                ChatWidget(mode: conversationMode, controller: chat)
+            }
+        }
+    }
+
+    // MARK: - Widget configuration
+
+    private var conversationMode: WidgetConversationMode {
+        switch mode {
+        case .voiceAndText: .voiceAndText(voiceAuth)
+        case .voiceOnly: .voiceOnly(voiceAuth)
+        case .textOnly: .textOnly(textOnlyAuth)
+        case .either: .voiceOrTextOnly(voice: voiceAuth, textOnly: textOnlyAuth)
+        }
+    }
+
+    private var voiceAuth: WidgetConversationMode.VoiceAuth {
+        switch auth {
+        case .publicAgent: .publicAgent(id: agentId.trimmed)
+        case .backend: .conversationToken { [token = conversationToken.trimmed] in token }
+        }
+    }
+
+    private var textOnlyAuth: WidgetConversationMode.TextOnlyAuth {
+        switch auth {
+        case .publicAgent: .publicAgent(id: agentId.trimmed)
+        case .backend: .signedWebSocketURL { [url = signedWebSocketURL.trimmed] in url }
+        }
+    }
+
+    /// Why the demo can't start yet, or nil when it can.
+    private var missingCredentials: String? {
+        switch auth {
+        case .publicAgent:
+            agentId.trimmed.isEmpty ? "Enter a public agent ID to try the widget." : nil
+        case .backend:
+            if mode.needsVoice, conversationToken.trimmed.isEmpty {
+                "Enter a conversation token from your backend for the voice call."
+            } else if mode.needsTextOnly, signedWebSocketURL.trimmed.isEmpty {
+                "Enter a signed WebSocket URL from your backend for text-only chat."
+            } else {
+                nil
+            }
+        }
+    }
+
+    // MARK: - Views
+
+    private var credentialsForm: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Picker("Mode", selection: $mode) {
+                ForEach(Mode.allCases) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Picker("Auth", selection: $auth) {
+                ForEach(Auth.allCases) { auth in
+                    Text(auth.rawValue).tag(auth)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            switch auth {
+            case .publicAgent:
+                TextField("Public agent ID", text: $agentId)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .textFieldStyle(.roundedBorder)
+            case .backend:
+                if mode.needsVoice {
+                    SecureField("Conversation token (voice)", text: $conversationToken)
+                        .textFieldStyle(.roundedBorder)
+                }
+                if mode.needsTextOnly {
+                    TextField("Signed WebSocket URL (text-only)", text: $signedWebSocketURL)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .textFieldStyle(.roundedBorder)
+                }
+            }
+        }
+    }
+
+    private var hostControls: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(stateDescription)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                Button("Open chat") { chat.open() }
+                Button("Close chat") { chat.close() }
+                Button("End call") {
+                    Task { await chat.endConversation() }
+                }
+                // Enabled while connecting too: ending is what cancels a start.
+                .disabled(!chat.state.isConnected && !chat.state.isConnecting)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    private var stateDescription: String {
+        switch chat.state {
+        case .idle: "Idle"
+        case .connecting: "Connecting…"
+        case .connected: "Connected"
+        case .ended: "Ended"
+        case .error: "Error"
+        }
+    }
+}
+
+extension String {
+    fileprivate var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,10 @@ let package = Package(
         .library(
             name: "ElevenLabs",
             targets: ["ElevenLabs"]
+        ),
+        .library(
+            name: "ElevenLabsWidget",
+            targets: ["ElevenLabsWidget"]
         )
     ],
     dependencies: [
@@ -35,6 +39,12 @@ let package = Package(
             ],
             resources: [
                 .process("PrivacyInfo.xcprivacy")
+            ]
+        ),
+        .target(
+            name: "ElevenLabsWidget",
+            dependencies: [
+                "ElevenLabs"
             ]
         ),
         .testTarget(

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -16,6 +16,10 @@ let package = Package(
         .library(
             name: "ElevenLabs",
             targets: ["ElevenLabs"]
+        ),
+        .library(
+            name: "ElevenLabsWidget",
+            targets: ["ElevenLabsWidget"]
         )
     ],
     dependencies: [
@@ -35,6 +39,12 @@ let package = Package(
             ],
             resources: [
                 .process("PrivacyInfo.xcprivacy")
+            ]
+        ),
+        .target(
+            name: "ElevenLabsWidget",
+            dependencies: [
+                "ElevenLabs"
             ]
         ),
         .testTarget(

--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -16,6 +16,10 @@ let package = Package(
         .library(
             name: "ElevenLabs",
             targets: ["ElevenLabs"]
+        ),
+        .library(
+            name: "ElevenLabsWidget",
+            targets: ["ElevenLabsWidget"]
         )
     ],
     dependencies: [
@@ -35,6 +39,12 @@ let package = Package(
             ],
             resources: [
                 .process("PrivacyInfo.xcprivacy")
+            ]
+        ),
+        .target(
+            name: "ElevenLabsWidget",
+            dependencies: [
+                "ElevenLabs"
             ]
         ),
         .testTarget(

--- a/Sources/ElevenLabs/Internal/Conversation/Conversation.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/Conversation.swift
@@ -123,6 +123,10 @@ final class Conversation: ObservableObject {
             try await startVoiceConversation(auth: auth)
         }
 
+        guard !Task.isCancelled, state.isConnecting else {
+            await activeConnectionManager?.disconnect()
+            throw CancellationError()
+        }
         state = .connected(result.callInfo)
         callbacks.onAgentReady?()
         return result
@@ -417,9 +421,10 @@ final class Conversation: ObservableObject {
     }
 
     private func handleStartupCancellation(disconnecting connectionManager: any ConnectionManaging) async {
-        guard state.isConnecting else { return }
-        state = .ended(reason: .userEnded)
-        tearDownActiveSession()
+        if state.isConnecting {
+            state = .ended(reason: .userEnded)
+            tearDownActiveSession()
+        }
         await connectionManager.disconnect()
     }
 

--- a/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
@@ -104,6 +104,7 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
 
         // 2. Request microphone permission (denial doesn't block startup).
         let permissionGranted = await requestMicrophonePermission()
+        try Task.checkCancellation()
 
         // 3. Connect the LiveKit room.
         onStartupStateChange(.connectingRoom)

--- a/Sources/ElevenLabsWidget/ChatWidgetController.swift
+++ b/Sources/ElevenLabsWidget/ChatWidgetController.swift
@@ -1,0 +1,93 @@
+#if canImport(UIKit)
+import ElevenLabs
+import Foundation
+
+/// Host-owned handle for observing widget state and driving it from outside.
+///
+/// Optional — pass one to ``ChatWidget`` to read state through the `@Published`
+/// mirrors and to issue commands.
+///
+/// The controller may outlive the widget: once the widget view is gone, commands
+/// become no-ops and the mirrors stop updating. Mirrors are read-only from the
+/// host so state only ever changes through a command.
+@available(iOS 16, macCatalyst 16, *)
+@MainActor
+public final class ChatWidgetController: ObservableObject {
+    @Published public internal(set) var state: ConversationState = .idle
+    @Published public internal(set) var isMicMuted = false
+    @Published public internal(set) var isOpen = false
+    /// Server-assigned conversation id; `nil` until the agent confirms the session.
+    @Published public internal(set) var conversationId: String?
+    @Published public internal(set) var messageCount = 0
+
+    public init() {}
+
+    public func open() {
+        binding?.open()
+    }
+
+    public func close() {
+        binding?.close()
+    }
+
+    public func toggleOpen() {
+        binding?.toggleOpen()
+    }
+
+    /// Start a conversation, awaiting the connection. No-op if one is live.
+    public func startConversation() async throws {
+        try await binding?.startConversationAndWait()
+    }
+
+    /// End the conversation, awaiting teardown. Cancels a start that hasn't
+    /// connected yet.
+    public func endConversation() async {
+        await binding?.endConversationAndWait()
+    }
+
+    /// Send a message as the user, connecting first if needed.
+    public func sendMessage(_ text: String) async throws {
+        try await binding?.send(text)
+    }
+
+    public func setMicMuted(_ muted: Bool) async throws {
+        try await binding?.client.setMicMuted(muted)
+    }
+
+    /// Snapshot of the conversation's messages. Not reactive — read it when you
+    /// need it (e.g. on end of call).
+    public func messages() -> [Message] {
+        binding?.client.messages ?? []
+    }
+
+    /// Set by the widget on attach. Weak so the controller can outlive the widget.
+    weak var binding: ChatWidgetViewModel?
+
+    /// Called when the widget goes away, since the mirrors would otherwise keep
+    /// reporting the last state of a conversation that no longer exists.
+    func reset() {
+        state = .idle
+        isMicMuted = false
+        isOpen = false
+        conversationId = nil
+        messageCount = 0
+    }
+}
+
+@available(iOS 16, macCatalyst 16, *)
+extension ChatWidgetViewModel {
+    func attach(to controller: ChatWidgetController) {
+        guard controller.binding !== self else { return }
+        controller.binding = self
+        self.controller = controller
+
+        $conversationState.assign(to: &controller.$state)
+        $isMicMuted.assign(to: &controller.$isMicMuted)
+        $isOpen.assign(to: &controller.$isOpen)
+        $messages.map(\.count).assign(to: &controller.$messageCount)
+        client.$conversationMetadata
+            .map { $0?.conversationId }
+            .assign(to: &controller.$conversationId)
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/ChatWidgetController.swift
+++ b/Sources/ElevenLabsWidget/ChatWidgetController.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import ElevenLabs
 import Foundation
 

--- a/Sources/ElevenLabsWidget/Configuration/ChatWidgetConfig.swift
+++ b/Sources/ElevenLabsWidget/Configuration/ChatWidgetConfig.swift
@@ -1,0 +1,27 @@
+#if canImport(UIKit)
+import Foundation
+
+/// Behavior and appearance of ``ChatWidget``.
+public struct ChatWidgetConfig: Equatable, Sendable {
+    /// Dim the host UI behind the open drawer.
+    public var showBackdrop: Bool
+    /// Show the microphone mute button while a conversation is live.
+    public var enableMicMuteControl: Bool
+    public var strings: ChatWidgetStrings
+    public var theme: ChatWidgetTheme
+
+    public init(
+        showBackdrop: Bool = true,
+        enableMicMuteControl: Bool = true,
+        strings: ChatWidgetStrings = .default,
+        theme: ChatWidgetTheme = .default
+    ) {
+        self.showBackdrop = showBackdrop
+        self.enableMicMuteControl = enableMicMuteControl
+        self.strings = strings
+        self.theme = theme
+    }
+
+    public static let `default` = ChatWidgetConfig()
+}
+#endif

--- a/Sources/ElevenLabsWidget/Configuration/ChatWidgetConfig.swift
+++ b/Sources/ElevenLabsWidget/Configuration/ChatWidgetConfig.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import Foundation
 
 /// Behavior and appearance of ``ChatWidget``.

--- a/Sources/ElevenLabsWidget/Configuration/ChatWidgetStrings.swift
+++ b/Sources/ElevenLabsWidget/Configuration/ChatWidgetStrings.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import Foundation
 
 /// User-facing copy for ``ChatWidget``. Override individual fields to localize

--- a/Sources/ElevenLabsWidget/Configuration/ChatWidgetStrings.swift
+++ b/Sources/ElevenLabsWidget/Configuration/ChatWidgetStrings.swift
@@ -1,0 +1,77 @@
+#if canImport(UIKit)
+import Foundation
+
+/// User-facing copy for ``ChatWidget``. Override individual fields to localize
+/// or reword; every field has an English default.
+public struct ChatWidgetStrings: Equatable, Sendable {
+    public var title: String
+    public var mainLabel: String
+    public var inputPlaceholder: String
+    public var openChatLabel: String
+    public var closeChatLabel: String
+    public var expandChatLabel: String
+    public var collapseChatLabel: String
+    public var sendMessageLabel: String
+    public var startConversationLabel: String
+    public var endConversationLabel: String
+    public var muteMicrophoneLabel: String
+    public var unmuteMicrophoneLabel: String
+    public var userEndedConversation: String
+    public var agentEndedConversation: String
+    public var conversationIdFormat: String
+    public var conversationStartFailed: String
+    public var conversationFailed: String
+    public var messageSendFailed: String
+    public var microphonePermissionDenied: String
+    public var openSettingsLabel: String
+    public var dismissLabel: String
+
+    public init(
+        title: String = "Chat",
+        mainLabel: String = "Powered by ElevenLabs",
+        inputPlaceholder: String = "Type a message…",
+        openChatLabel: String = "Open chat",
+        closeChatLabel: String = "Close chat",
+        expandChatLabel: String = "Expand chat",
+        collapseChatLabel: String = "Collapse chat",
+        sendMessageLabel: String = "Send message",
+        startConversationLabel: String = "Start voice conversation",
+        endConversationLabel: String = "End conversation",
+        muteMicrophoneLabel: String = "Mute microphone",
+        unmuteMicrophoneLabel: String = "Unmute microphone",
+        userEndedConversation: String = "You ended the conversation.",
+        agentEndedConversation: String = "The agent ended the conversation.",
+        conversationIdFormat: String = "Conversation ID: %@",
+        conversationStartFailed: String = "The conversation couldn't be started.",
+        conversationFailed: String = "The conversation ran into a problem.",
+        messageSendFailed: String = "That message couldn't be sent.",
+        microphonePermissionDenied: String = "Microphone access is off, so the agent can't hear you.",
+        openSettingsLabel: String = "Settings",
+        dismissLabel: String = "Dismiss"
+    ) {
+        self.title = title
+        self.mainLabel = mainLabel
+        self.inputPlaceholder = inputPlaceholder
+        self.openChatLabel = openChatLabel
+        self.closeChatLabel = closeChatLabel
+        self.expandChatLabel = expandChatLabel
+        self.collapseChatLabel = collapseChatLabel
+        self.sendMessageLabel = sendMessageLabel
+        self.startConversationLabel = startConversationLabel
+        self.endConversationLabel = endConversationLabel
+        self.muteMicrophoneLabel = muteMicrophoneLabel
+        self.unmuteMicrophoneLabel = unmuteMicrophoneLabel
+        self.userEndedConversation = userEndedConversation
+        self.agentEndedConversation = agentEndedConversation
+        self.conversationIdFormat = conversationIdFormat
+        self.conversationStartFailed = conversationStartFailed
+        self.conversationFailed = conversationFailed
+        self.messageSendFailed = messageSendFailed
+        self.microphonePermissionDenied = microphonePermissionDenied
+        self.openSettingsLabel = openSettingsLabel
+        self.dismissLabel = dismissLabel
+    }
+
+    public static let `default` = ChatWidgetStrings()
+}
+#endif

--- a/Sources/ElevenLabsWidget/Configuration/ChatWidgetTheme.swift
+++ b/Sources/ElevenLabsWidget/Configuration/ChatWidgetTheme.swift
@@ -1,0 +1,53 @@
+#if canImport(UIKit)
+import SwiftUI
+
+/// Visual styling for ``ChatWidget``. Defaults mirror the ElevenLabs web widget.
+public struct ChatWidgetTheme: Equatable, Sendable {
+    /// Hairline borders around buttons and the composer.
+    public var border: Color
+    /// Saturated red used for the end-call glyph.
+    public var destructive: Color
+    /// Soft fill behind the end-call button.
+    public var destructiveTint: Color
+    /// Primary (darker) color in the orb gradient.
+    public var orbPrimary: Color
+    /// Secondary (lighter) color in the orb gradient.
+    public var orbSecondary: Color
+
+    public init(
+        border: Color = ChatWidgetTheme.default.border,
+        destructive: Color = ChatWidgetTheme.default.destructive,
+        destructiveTint: Color = ChatWidgetTheme.default.destructiveTint,
+        orbPrimary: Color = ChatWidgetTheme.default.orbPrimary,
+        orbSecondary: Color = ChatWidgetTheme.default.orbSecondary
+    ) {
+        self.border = border
+        self.destructive = destructive
+        self.destructiveTint = destructiveTint
+        self.orbPrimary = orbPrimary
+        self.orbSecondary = orbSecondary
+    }
+
+    public static let `default` = ChatWidgetTheme(
+        border: Color(hex: 0xE1E1E1),
+        destructive: Color(hex: 0xFF1900),
+        destructiveTint: Color(hex: 0xFDE4E3),
+        orbPrimary: Color(hex: 0x2792DC),
+        orbSecondary: Color(hex: 0x9CE6E6)
+    )
+}
+
+extension Color {
+    /// Build a `Color` from a 24-bit `0xRRGGBB` value, matching the hex strings
+    /// used by the web widget config (e.g. `#2792dc` → `0x2792DC`).
+    init(hex: UInt32) {
+        self.init(
+            .sRGB,
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255,
+            opacity: 1
+        )
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Configuration/ChatWidgetTheme.swift
+++ b/Sources/ElevenLabsWidget/Configuration/ChatWidgetTheme.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import SwiftUI
 
 /// Visual styling for ``ChatWidget``. Defaults mirror the ElevenLabs web widget.

--- a/Sources/ElevenLabsWidget/Configuration/WidgetConversationMode.swift
+++ b/Sources/ElevenLabsWidget/Configuration/WidgetConversationMode.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import ElevenLabs
 import Foundation
 

--- a/Sources/ElevenLabsWidget/Configuration/WidgetConversationMode.swift
+++ b/Sources/ElevenLabsWidget/Configuration/WidgetConversationMode.swift
@@ -1,0 +1,116 @@
+#if canImport(UIKit)
+import ElevenLabs
+import Foundation
+
+/// How the user can talk to the agent through ``ChatWidget``, and how each kind
+/// of session authenticates.
+///
+/// Voice runs over WebRTC and text-only over a WebSocket, and the two take
+/// different credentials. Carrying the credentials in the mode means a widget
+/// can never be configured for a session it has no way to authenticate.
+public enum WidgetConversationMode: Sendable {
+    /// Typed messages only; the conversation runs without audio.
+    case textOnly(TextOnlyAuth)
+    /// A voice call with no composer.
+    case voiceOnly(VoiceAuth, showsTranscript: Bool = true)
+    /// A voice call the user can also type into.
+    case voiceAndText(VoiceAuth)
+    /// The user picks per session: the call button starts a voice call, typing
+    /// the first message starts a text-only one.
+    case voiceOrTextOnly(voice: VoiceAuth, textOnly: TextOnlyAuth)
+
+    public enum VoiceAuth: Sendable {
+        case publicAgent(id: String, environment: String? = nil)
+        /// Mints a conversation token from your backend for each call.
+        case conversationToken(@Sendable () async throws -> String)
+    }
+
+    public enum TextOnlyAuth: Sendable {
+        case publicAgent(id: String, environment: String? = nil)
+        /// Mints a signed WebSocket URL from your backend for each session.
+        case signedWebSocketURL(@Sendable () async throws -> String)
+    }
+}
+
+/// The session ``ChatWidget`` is about to open.
+enum WidgetSessionKind: Equatable {
+    case voice
+    case textOnly
+}
+
+extension WidgetConversationMode {
+    var supportsVoice: Bool {
+        if case .textOnly = self {
+            false
+        } else {
+            true
+        }
+    }
+
+    var supportsTextInput: Bool {
+        if case .voiceOnly = self {
+            false
+        } else {
+            true
+        }
+    }
+
+    var showsTranscript: Bool {
+        if case let .voiceOnly(_, showsTranscript) = self {
+            showsTranscript
+        } else { true }
+    }
+
+    /// The call button, and the host's `startConversation()`, open this kind of session.
+    var requestedSessionKind: WidgetSessionKind {
+        supportsVoice ? .voice : .textOnly
+    }
+
+    /// A message typed with nothing running opens this kind of session.
+    var typedSessionKind: WidgetSessionKind {
+        switch self {
+        case .textOnly, .voiceOrTextOnly: .textOnly
+        case .voiceOnly, .voiceAndText: .voice
+        }
+    }
+
+    /// Minted per start, so tokens and signed URLs are never reused across sessions.
+    func credentials(for kind: WidgetSessionKind) async throws -> ConversationCredentials {
+        switch self {
+        case let .textOnly(auth):
+            try await auth.credentials()
+        case let .voiceOnly(auth, _):
+            try await auth.credentials()
+        case let .voiceAndText(auth):
+            try await auth.credentials()
+        case let .voiceOrTextOnly(voice, textOnly):
+            switch kind {
+            case .voice: try await voice.credentials()
+            case .textOnly: try await textOnly.credentials()
+            }
+        }
+    }
+}
+
+extension WidgetConversationMode.VoiceAuth {
+    func credentials() async throws -> ConversationCredentials {
+        switch self {
+        case let .publicAgent(id, environment):
+            .publicAgent(id: id, environment: environment)
+        case let .conversationToken(mint):
+            try await .conversationToken(mint())
+        }
+    }
+}
+
+extension WidgetConversationMode.TextOnlyAuth {
+    func credentials() async throws -> ConversationCredentials {
+        switch self {
+        case let .publicAgent(id, environment):
+            .publicAgent(id: id, environment: environment)
+        case let .signedWebSocketURL(mint):
+            try await .signedWebSocketURL(mint())
+        }
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Models/ChatMessage.swift
+++ b/Sources/ElevenLabsWidget/Models/ChatMessage.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import ElevenLabs
 import Foundation
 

--- a/Sources/ElevenLabsWidget/Models/ChatMessage.swift
+++ b/Sources/ElevenLabsWidget/Models/ChatMessage.swift
@@ -1,0 +1,21 @@
+#if canImport(UIKit)
+import ElevenLabs
+import Foundation
+
+/// A transcript bubble, projected from the SDK's ``Message``.
+struct ChatMessage: Identifiable, Equatable {
+    enum Role: Equatable { case user, agent }
+
+    let id: String
+    let role: Role
+    let content: String
+    let timestamp: Date
+
+    init(_ message: Message) {
+        id = message.id
+        role = message.role == .user ? .user : .agent
+        content = message.content
+        timestamp = message.timestamp
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Models/ChatWidgetBanner.swift
+++ b/Sources/ElevenLabsWidget/Models/ChatWidgetBanner.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import AVFoundation
 import Foundation
 import UIKit

--- a/Sources/ElevenLabsWidget/Models/ChatWidgetBanner.swift
+++ b/Sources/ElevenLabsWidget/Models/ChatWidgetBanner.swift
@@ -1,0 +1,32 @@
+#if canImport(UIKit)
+import AVFoundation
+import Foundation
+import UIKit
+
+/// A transient message shown across the top of the drawer.
+struct ChatWidgetBanner: Equatable {
+    let message: String
+    /// Permission problems can't be fixed in-app, so those banners offer Settings.
+    let offersSettings: Bool
+
+    init(_ message: String, offersSettings: Bool = false) {
+        self.message = message
+        self.offersSettings = offersSettings
+    }
+}
+
+enum MicrophonePermission {
+    static var isDenied: Bool {
+        if #available(iOS 17, macCatalyst 17, *) {
+            return AVAudioApplication.shared.recordPermission == .denied
+        }
+        return AVAudioSession.sharedInstance().recordPermission == .denied
+    }
+
+    @MainActor
+    static func openSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/ViewModels/ChatWidgetViewModel.swift
+++ b/Sources/ElevenLabsWidget/ViewModels/ChatWidgetViewModel.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import Combine
 import ElevenLabs
 import Foundation
@@ -29,14 +29,14 @@ final class ChatWidgetViewModel: ObservableObject {
         let endedByUser: Bool
     }
 
-    /// All three mirror what the host passes to ``ChatWidget``, so changes land
+    /// All four mirror what the host passes to ``ChatWidget``, so changes land
     /// on the live view model instead of needing a new conversation.
     var mode: WidgetConversationMode
+    var conversationConfig: ConversationConfig
     var onClientToolCall: (@MainActor (ClientToolCallEvent) async -> ClientToolResultEvent)?
     @Published var widgetConfig: ChatWidgetConfig
     let client: ConversationClient
 
-    private let conversationConfig: ConversationConfig
     /// Tool calls already dispatched, so a re-published snapshot doesn't run them twice.
     private var dispatchedToolCallIds: Set<String> = []
     /// The in-flight startup, so overlapping callers join it instead of racing.
@@ -69,6 +69,9 @@ final class ChatWidgetViewModel: ObservableObject {
             .map { $0.map(ChatMessage.init) }
             .assign(to: &$messages)
         client.$pendingToolCalls
+            .combineLatest(client.$state)
+            .filter { _, state in state.isConnected }
+            .map { calls, _ in calls }
             .sink { [weak self] in self?.dispatchNewToolCalls($0) }
             .store(in: &cancellables)
         // Only a finished session clears the kind: the client rebinds to a fresh
@@ -80,6 +83,7 @@ final class ChatWidgetViewModel: ObservableObject {
                 switch state {
                 case let .ended(reason):
                     sessionKind = nil
+                    dismissBanner()
                     endedConversation = EndedConversation(
                         id: client.conversationMetadata?.conversationId,
                         endedByUser: reason == .userEnded
@@ -185,7 +189,6 @@ final class ChatWidgetViewModel: ObservableObject {
         Task {
             do {
                 try await startConversationAndWait()
-                warnIfMicrophoneUnavailable()
             } catch is CancellationError {
                 // The user ended the call before it connected.
             } catch {
@@ -219,10 +222,14 @@ final class ChatWidgetViewModel: ObservableObject {
         // No start in flight, so a kind here means a session already connected.
         guard sessionKind == nil else { return }
         let mode = mode
+        let client = client
         let config = conversationConfig(for: kind)
+        dispatchedToolCallIds.removeAll()
         let task = Task {
+            let credentials = try await mode.credentials(for: kind)
+            try Task.checkCancellation()
             _ = try await client.startConversation(
-                auth: mode.credentials(for: kind),
+                auth: credentials,
                 config: config
             )
         }
@@ -236,19 +243,22 @@ final class ChatWidgetViewModel: ObservableObject {
         defer { if sessionGeneration == generation { startTask = nil } }
         do {
             try await task.value
+            warnIfMicrophoneUnavailable()
         } catch {
             // Minting can fail before the client ever leaves idle, and then no
             // state arrives to retire the session this would have been.
             if sessionGeneration == generation { sessionKind = nil }
+            if task.isCancelled || error is CancellationError {
+                throw CancellationError()
+            }
             throw error
         }
     }
 
     /// Text-only sessions run the conversation without audio.
     private func conversationConfig(for kind: WidgetSessionKind) -> ConversationConfig {
-        guard kind == .textOnly else { return conversationConfig }
         var config = conversationConfig
-        config.conversationOverrides.textOnly = true
+        config.conversationOverrides.textOnly = kind == .textOnly
         return config
     }
 
@@ -259,17 +269,11 @@ final class ChatWidgetViewModel: ObservableObject {
     /// Ending has to outrank a start that is still resolving credentials, or the
     /// connection lands afterwards and leaves the microphone live.
     func endConversationAndWait() async {
-        let start = startTask
-        let generation = sessionGeneration
+        let task = startTask?.task
         startTask = nil
         sessionKind = nil
-        start?.task.cancel()
+        task?.cancel()
         await client.endConversation()
-        guard let start else { return }
-        // A start that ignored the cancel still connects, so wait it out and
-        // tear it down — unless a newer session has begun in the meantime.
-        _ = try? await start.task.value
-        if sessionGeneration == generation { await client.endConversation() }
     }
 
     func send() {
@@ -277,10 +281,12 @@ final class ChatWidgetViewModel: ObservableObject {
         guard !text.isEmpty, !isSending else { return }
         input = ""
         isSending = true
-        dismissBanner()
+        if banner?.offersSettings != true { dismissBanner() }
         Task {
             do {
                 try await send(text)
+            } catch is CancellationError {
+                if input.isEmpty { input = text }
             } catch {
                 // Hand the text back so the user can retry rather than losing it.
                 if input.isEmpty { input = text }
@@ -304,17 +310,20 @@ final class ChatWidgetViewModel: ObservableObject {
     private func show(_ banner: ChatWidgetBanner) {
         self.banner = banner
         bannerDismissal?.cancel()
+        bannerDismissal = nil
         // A banner offering Settings needs to stay until it is acted on.
         guard !banner.offersSettings else { return }
         bannerDismissal = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 5_000_000_000)
             guard !Task.isCancelled else { return }
             self?.banner = nil
+            self?.bannerDismissal = nil
         }
     }
 
     func dismissBanner() {
         bannerDismissal?.cancel()
+        bannerDismissal = nil
         banner = nil
     }
 
@@ -328,36 +337,33 @@ final class ChatWidgetViewModel: ObservableObject {
     private func dispatchNewToolCalls(_ calls: [ClientToolCallEvent]) {
         let ids = Set(calls.map(\.toolCallId))
         let added = ids.subtracting(dispatchedToolCallIds)
-        dispatchedToolCallIds = ids
+        dispatchedToolCallIds.formUnion(added)
         for call in calls where added.contains(call.toolCallId) {
             dispatch(call)
         }
     }
 
     private func dispatch(_ call: ClientToolCallEvent) {
-        guard let onClientToolCall else {
-            respond(to: call, with: .init(
-                toolCallId: call.toolCallId,
-                result: "No client tool handler is configured in the app.",
-                isError: true
-            ))
-            return
-        }
         let generation = sessionGeneration
+        let handler = onClientToolCall
         Task { @MainActor [weak self] in
-            let result = await onClientToolCall(call)
+            let result = if let handler {
+                await handler(call)
+            } else {
+                ClientToolResultEvent(
+                    toolCallId: call.toolCallId,
+                    result: "No client tool handler is configured in the app.",
+                    isError: true
+                )
+            }
             // The host handler can outlive the conversation that asked for it.
             guard let self, generation == sessionGeneration else { return }
-            respond(to: call, with: result)
+            if call.expectsResponse {
+                try? await client.sendToolResult(result)
+            } else {
+                client.markToolCallCompleted(call.toolCallId)
+            }
         }
-    }
-
-    private func respond(to call: ClientToolCallEvent, with result: ClientToolResultEvent) {
-        guard call.expectsResponse else {
-            client.markToolCallCompleted(call.toolCallId)
-            return
-        }
-        Task { try? await client.sendToolResult(result) }
     }
 }
 #endif

--- a/Sources/ElevenLabsWidget/ViewModels/ChatWidgetViewModel.swift
+++ b/Sources/ElevenLabsWidget/ViewModels/ChatWidgetViewModel.swift
@@ -1,0 +1,363 @@
+#if canImport(UIKit)
+import Combine
+import ElevenLabs
+import Foundation
+import SwiftUI
+import UIKit
+
+@available(iOS 16, macCatalyst 16, *)
+@MainActor
+final class ChatWidgetViewModel: ObservableObject {
+    @Published var isOpen = false
+    @Published var input = ""
+    @Published private(set) var messages: [ChatMessage] = []
+    @Published private(set) var conversationState: ConversationState = .idle
+    @Published private(set) var agentState: AgentState = .listening
+    @Published private(set) var isMicMuted = false
+    @Published private(set) var isSending = false
+    /// The session the widget has going, from the moment one is requested —
+    /// before its credentials are minted — until it ends or fails. The UI follows
+    /// this rather than everything the mode allows.
+    @Published private(set) var sessionKind: WidgetSessionKind?
+    @Published private(set) var banner: ChatWidgetBanner?
+    /// Closes off the transcript once a session is over, and carries the id the
+    /// user would quote in a support request.
+    @Published private(set) var endedConversation: EndedConversation?
+
+    struct EndedConversation: Equatable {
+        let id: String?
+        let endedByUser: Bool
+    }
+
+    /// All three mirror what the host passes to ``ChatWidget``, so changes land
+    /// on the live view model instead of needing a new conversation.
+    var mode: WidgetConversationMode
+    var onClientToolCall: (@MainActor (ClientToolCallEvent) async -> ClientToolResultEvent)?
+    @Published var widgetConfig: ChatWidgetConfig
+    let client: ConversationClient
+
+    private let conversationConfig: ConversationConfig
+    /// Tool calls already dispatched, so a re-published snapshot doesn't run them twice.
+    private var dispatchedToolCallIds: Set<String> = []
+    /// The in-flight startup, so overlapping callers join it instead of racing.
+    private var startTask: (kind: WidgetSessionKind, task: Task<Void, Error>)?
+    /// Bumped per start, so work outliving a session can tell it went stale.
+    private var sessionGeneration = 0
+    /// Reset on teardown, so a host keeping it doesn't read a dead session's state.
+    weak var controller: ChatWidgetController?
+    private var bannerDismissal: Task<Void, Never>?
+    private var cancellables = Set<AnyCancellable>()
+
+    init(
+        mode: WidgetConversationMode,
+        widgetConfig: ChatWidgetConfig,
+        client: ConversationClient,
+        conversationConfig: ConversationConfig,
+        onClientToolCall: (@MainActor (ClientToolCallEvent) async -> ClientToolResultEvent)?
+    ) {
+        self.mode = mode
+        self.widgetConfig = widgetConfig
+        self.client = client
+        self.conversationConfig = conversationConfig
+        self.onClientToolCall = onClientToolCall
+
+        // The client is durable across sessions, so every subscription is wired once.
+        client.$state.assign(to: &$conversationState)
+        client.$agentState.assign(to: &$agentState)
+        client.$isMicMuted.assign(to: &$isMicMuted)
+        client.$messages
+            .map { $0.map(ChatMessage.init) }
+            .assign(to: &$messages)
+        client.$pendingToolCalls
+            .sink { [weak self] in self?.dispatchNewToolCalls($0) }
+            .store(in: &cancellables)
+        // Only a finished session clears the kind: the client rebinds to a fresh
+        // conversation on every start, and that publishes `.idle` before it
+        // connects, which would wipe the kind of the session just requested.
+        client.$state
+            .sink { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case let .ended(reason):
+                    sessionKind = nil
+                    endedConversation = EndedConversation(
+                        id: client.conversationMetadata?.conversationId,
+                        endedByUser: reason == .userEnded
+                    )
+                case .error:
+                    sessionKind = nil
+                    // The error itself stays on `conversationState` for the host;
+                    // the banner is user-facing copy the host can reword.
+                    show(ChatWidgetBanner(strings.conversationFailed))
+                default:
+                    break
+                }
+            }
+            .store(in: &cancellables)
+    }
+
+    /// The host can drop the widget mid-call, and nothing else owns the client,
+    /// so the session and the microphone would otherwise stay live. The
+    /// controller's mirrors freeze on the last value once we stop publishing,
+    /// so they are cleared rather than left reading `connected`.
+    deinit {
+        let client = client
+        let controller = controller
+        Task { @MainActor in
+            await client.endConversation()
+            // A replacement widget can attach while this teardown is suspended.
+            // The binding is weak, so it is nil only if we were the last one.
+            if controller?.binding == nil { controller?.reset() }
+        }
+    }
+
+    // MARK: - Derived state
+
+    private var strings: ChatWidgetStrings {
+        widgetConfig.strings
+    }
+
+    var canEndConversation: Bool {
+        sessionKind != nil
+    }
+
+    var canSend: Bool {
+        !isSending && !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var canToggleMicMute: Bool {
+        widgetConfig.enableMicMuteControl && sessionKind == .voice && conversationState.isConnected
+    }
+
+    var canShowTextInput: Bool {
+        mode.supportsTextInput
+    }
+
+    var supportsVoice: Bool {
+        mode.supportsVoice
+    }
+
+    var canStartVoiceConversation: Bool {
+        supportsVoice && sessionKind == nil
+    }
+
+    var showsTranscript: Bool {
+        mode.showsTranscript
+    }
+
+    var orbState: ChatOrbState {
+        switch conversationState {
+        case .idle, .ended, .error: .disconnected
+        case .connecting: .connecting
+        case .connected: agentState == .speaking ? .speaking : .listening
+        }
+    }
+
+    // MARK: - Presentation
+
+    func open() {
+        setOpen(true)
+    }
+
+    func close() {
+        setOpen(false)
+    }
+
+    func toggleOpen() {
+        setOpen(!isOpen)
+    }
+
+    /// Every open and close goes through here, including the host's, so the
+    /// drawer animates and the keyboard retracts with it either way.
+    private func setOpen(_ open: Bool) {
+        guard open != isOpen else { return }
+        if !open {
+            UIApplication.shared.sendAction(
+                #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+            )
+        }
+        withAnimation(.spring(response: 0.42, dampingFraction: 0.82)) { isOpen = open }
+    }
+
+    // MARK: - Conversation
+
+    func startConversation() {
+        Task {
+            do {
+                try await startConversationAndWait()
+                warnIfMicrophoneUnavailable()
+            } catch is CancellationError {
+                // The user ended the call before it connected.
+            } catch {
+                show(ChatWidgetBanner(strings.conversationStartFailed))
+            }
+        }
+    }
+
+    /// The SDK connects muted rather than failing when the microphone is off, so
+    /// the widget is what tells the user why nobody can hear them.
+    private func warnIfMicrophoneUnavailable() {
+        guard sessionKind == .voice, MicrophonePermission.isDenied else { return }
+        show(ChatWidgetBanner(strings.microphonePermissionDenied, offersSettings: true))
+    }
+
+    func startConversationAndWait() async throws {
+        try await startConversationAndWait(mode.requestedSessionKind)
+    }
+
+    private func startConversationAndWait(_ kind: WidgetSessionKind) async throws {
+        // Joining first matters while connecting: returning early there would let
+        // a send reach the agent before the session is up. A voice session also
+        // carries typed messages, but a text-only one has no microphone to call
+        // over, so that pairing can't be joined.
+        if let startTask {
+            guard startTask.kind == .voice || kind == .textOnly else {
+                throw ConversationError.alreadyStarted
+            }
+            return try await startTask.task.value
+        }
+        // No start in flight, so a kind here means a session already connected.
+        guard sessionKind == nil else { return }
+        let mode = mode
+        let config = conversationConfig(for: kind)
+        let task = Task {
+            _ = try await client.startConversation(
+                auth: mode.credentials(for: kind),
+                config: config
+            )
+        }
+        sessionKind = kind
+        endedConversation = nil
+        sessionGeneration += 1
+        startTask = (kind, task)
+        let generation = sessionGeneration
+        // Only our own start is cleared: an end, or a later start, may have
+        // replaced it while we were connecting.
+        defer { if sessionGeneration == generation { startTask = nil } }
+        do {
+            try await task.value
+        } catch {
+            // Minting can fail before the client ever leaves idle, and then no
+            // state arrives to retire the session this would have been.
+            if sessionGeneration == generation { sessionKind = nil }
+            throw error
+        }
+    }
+
+    /// Text-only sessions run the conversation without audio.
+    private func conversationConfig(for kind: WidgetSessionKind) -> ConversationConfig {
+        guard kind == .textOnly else { return conversationConfig }
+        var config = conversationConfig
+        config.conversationOverrides.textOnly = true
+        return config
+    }
+
+    func endConversation() {
+        Task { await endConversationAndWait() }
+    }
+
+    /// Ending has to outrank a start that is still resolving credentials, or the
+    /// connection lands afterwards and leaves the microphone live.
+    func endConversationAndWait() async {
+        let start = startTask
+        let generation = sessionGeneration
+        startTask = nil
+        sessionKind = nil
+        start?.task.cancel()
+        await client.endConversation()
+        guard let start else { return }
+        // A start that ignored the cancel still connects, so wait it out and
+        // tear it down — unless a newer session has begun in the meantime.
+        _ = try? await start.task.value
+        if sessionGeneration == generation { await client.endConversation() }
+    }
+
+    func send() {
+        let text = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, !isSending else { return }
+        input = ""
+        isSending = true
+        dismissBanner()
+        Task {
+            do {
+                try await send(text)
+            } catch {
+                // Hand the text back so the user can retry rather than losing it.
+                if input.isEmpty { input = text }
+                show(ChatWidgetBanner(strings.messageSendFailed))
+            }
+            isSending = false
+        }
+    }
+
+    func send(_ text: String) async throws {
+        try await startConversationAndWait(mode.typedSessionKind)
+        try await client.sendMessage(text)
+    }
+
+    func toggleMicMute() {
+        Task { try? await client.setMicMuted(!isMicMuted) }
+    }
+
+    // MARK: - Banner
+
+    private func show(_ banner: ChatWidgetBanner) {
+        self.banner = banner
+        bannerDismissal?.cancel()
+        // A banner offering Settings needs to stay until it is acted on.
+        guard !banner.offersSettings else { return }
+        bannerDismissal = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            guard !Task.isCancelled else { return }
+            self?.banner = nil
+        }
+    }
+
+    func dismissBanner() {
+        bannerDismissal?.cancel()
+        banner = nil
+    }
+
+    func openSettings() {
+        dismissBanner()
+        MicrophonePermission.openSettings()
+    }
+
+    // MARK: - Client tools
+
+    private func dispatchNewToolCalls(_ calls: [ClientToolCallEvent]) {
+        let ids = Set(calls.map(\.toolCallId))
+        let added = ids.subtracting(dispatchedToolCallIds)
+        dispatchedToolCallIds = ids
+        for call in calls where added.contains(call.toolCallId) {
+            dispatch(call)
+        }
+    }
+
+    private func dispatch(_ call: ClientToolCallEvent) {
+        guard let onClientToolCall else {
+            respond(to: call, with: .init(
+                toolCallId: call.toolCallId,
+                result: "No client tool handler is configured in the app.",
+                isError: true
+            ))
+            return
+        }
+        let generation = sessionGeneration
+        Task { @MainActor [weak self] in
+            let result = await onClientToolCall(call)
+            // The host handler can outlive the conversation that asked for it.
+            guard let self, generation == sessionGeneration else { return }
+            respond(to: call, with: result)
+        }
+    }
+
+    private func respond(to call: ClientToolCallEvent, with result: ClientToolResultEvent) {
+        guard call.expectsResponse else {
+            client.markToolCallCompleted(call.toolCallId)
+            return
+        }
+        Task { try? await client.sendToolResult(result) }
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Views/ChatBannerView.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatBannerView.swift
@@ -1,0 +1,46 @@
+#if canImport(UIKit)
+import SwiftUI
+
+/// Failures and permission problems, shown across the top of the drawer.
+@available(iOS 16, macCatalyst 16, *)
+struct ChatBannerView: View {
+    let banner: ChatWidgetBanner
+    let strings: ChatWidgetStrings
+    let theme: ChatWidgetTheme
+    let onOpenSettings: () -> Void
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(theme.destructive)
+
+            Text(banner.message)
+                .font(.footnote)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if banner.offersSettings {
+                Button(strings.openSettingsLabel, action: onOpenSettings)
+                    .font(.footnote.weight(.semibold))
+                    .buttonStyle(.plain)
+            }
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(strings.dismissLabel)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(theme.destructiveTint)
+        )
+        .padding(.horizontal, 12)
+        .padding(.bottom, 8)
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Views/ChatBannerView.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatBannerView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import SwiftUI
 
 /// Failures and permission problems, shown across the top of the drawer.

--- a/Sources/ElevenLabsWidget/Views/ChatDrawerDetent.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatDrawerDetent.swift
@@ -1,0 +1,9 @@
+#if canImport(UIKit)
+import Foundation
+
+/// Drawer heights the user can drag between.
+enum ChatDrawerDetent {
+    case compact
+    case expanded
+}
+#endif

--- a/Sources/ElevenLabsWidget/Views/ChatDrawerDetent.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatDrawerDetent.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import Foundation
 
 /// Drawer heights the user can drag between.

--- a/Sources/ElevenLabsWidget/Views/ChatInputBar.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatInputBar.swift
@@ -1,0 +1,102 @@
+#if canImport(UIKit)
+import SwiftUI
+
+/// Composer plus the mic / start / end / send controls.
+@available(iOS 16, macCatalyst 16, *)
+struct ChatInputBar: View {
+    @ObservedObject var vm: ChatWidgetViewModel
+    var isInputFocused: FocusState<Bool>.Binding
+
+    private var strings: ChatWidgetStrings {
+        vm.widgetConfig.strings
+    }
+
+    private var theme: ChatWidgetTheme {
+        vm.widgetConfig.theme
+    }
+
+    var body: some View {
+        VStack(spacing: 10) {
+            if vm.canShowTextInput {
+                TextField(strings.inputPlaceholder, text: $vm.input, axis: .vertical)
+                    .textFieldStyle(.plain)
+                    .lineLimit(1 ... 3)
+                    .padding(.horizontal, 8)
+                    .frame(minHeight: 36)
+                    .focused(isInputFocused)
+                    .onSubmit(vm.send)
+            }
+
+            HStack(spacing: 10) {
+                if vm.canToggleMicMute {
+                    ChatMicButton(vm: vm, diameter: 38, theme: theme)
+                }
+                Spacer(minLength: 0)
+                if vm.canEndConversation {
+                    endConversationButton
+                } else if vm.canStartVoiceConversation {
+                    startConversationButton
+                }
+                if vm.canShowTextInput {
+                    sendButton
+                } else {
+                    // Without a composer there is nothing to push the call
+                    // controls away from, so they sit centered instead.
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .fill(Color(.systemBackground))
+                .shadow(color: .black.opacity(0.08), radius: 8, y: 2)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .strokeBorder(theme.border, lineWidth: 1)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture { if vm.canShowTextInput { isInputFocused.wrappedValue = true } }
+    }
+
+    private var startConversationButton: some View {
+        Button(action: vm.startConversation) {
+            circle(fill: Color(.systemBackground), glyph: "phone.fill", tint: .black)
+                .overlay(Circle().strokeBorder(theme.border, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(strings.startConversationLabel)
+    }
+
+    private var endConversationButton: some View {
+        Button(action: vm.endConversation) {
+            circle(fill: theme.destructiveTint, glyph: "phone.down.fill", tint: theme.destructive)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(strings.endConversationLabel)
+    }
+
+    private var sendButton: some View {
+        Button(action: vm.send) {
+            circle(
+                fill: vm.canSend ? Color.black : Color.secondary.opacity(0.4),
+                glyph: "paperplane.fill",
+                tint: .white
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(!vm.canSend)
+        .accessibilityLabel(strings.sendMessageLabel)
+    }
+
+    private func circle(fill: Color, glyph: String, tint: Color) -> some View {
+        Image(systemName: glyph)
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundColor(tint)
+            .frame(width: 38, height: 38)
+            .background(Circle().fill(fill))
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Views/ChatInputBar.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatInputBar.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import SwiftUI
 
 /// Composer plus the mic / start / end / send controls.
@@ -63,7 +63,7 @@ struct ChatInputBar: View {
 
     private var startConversationButton: some View {
         Button(action: vm.startConversation) {
-            circle(fill: Color(.systemBackground), glyph: "phone.fill", tint: .black)
+            circle(fill: Color(.systemBackground), glyph: "phone.fill", tint: .primary)
                 .overlay(Circle().strokeBorder(theme.border, lineWidth: 1))
         }
         .buttonStyle(.plain)

--- a/Sources/ElevenLabsWidget/Views/ChatMicButton.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatMicButton.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import SwiftUI
 
 /// Circular microphone toggle with a muted slash.
@@ -12,7 +12,7 @@ struct ChatMicButton: View {
         Button(action: vm.toggleMicMute) {
             Image(systemName: vm.isMicMuted ? "mic.slash.fill" : "mic.fill")
                 .font(.system(size: diameter * 0.42))
-                .foregroundColor(.black)
+                .foregroundColor(.primary)
                 .frame(width: diameter, height: diameter)
                 .background(Circle().fill(Color(.systemBackground)))
                 .overlay(Circle().strokeBorder(theme.border, lineWidth: 1))

--- a/Sources/ElevenLabsWidget/Views/ChatMicButton.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatMicButton.swift
@@ -1,0 +1,28 @@
+#if canImport(UIKit)
+import SwiftUI
+
+/// Circular microphone toggle with a muted slash.
+@available(iOS 16, macCatalyst 16, *)
+struct ChatMicButton: View {
+    @ObservedObject var vm: ChatWidgetViewModel
+    let diameter: CGFloat
+    var theme: ChatWidgetTheme = .default
+
+    var body: some View {
+        Button(action: vm.toggleMicMute) {
+            Image(systemName: vm.isMicMuted ? "mic.slash.fill" : "mic.fill")
+                .font(.system(size: diameter * 0.42))
+                .foregroundColor(.black)
+                .frame(width: diameter, height: diameter)
+                .background(Circle().fill(Color(.systemBackground)))
+                .overlay(Circle().strokeBorder(theme.border, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(
+            vm.isMicMuted
+                ? vm.widgetConfig.strings.unmuteMicrophoneLabel
+                : vm.widgetConfig.strings.muteMicrophoneLabel
+        )
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Views/ChatOrbView.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatOrbView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import SwiftUI
 
 enum ChatOrbState {

--- a/Sources/ElevenLabsWidget/Views/ChatOrbView.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatOrbView.swift
@@ -1,0 +1,39 @@
+#if canImport(UIKit)
+import SwiftUI
+
+enum ChatOrbState {
+    case connecting
+    case listening
+    case speaking
+    case disconnected
+}
+
+/// Placeholder orb: a themed gradient sphere that breathes while the agent is
+/// speaking. Replaced by the Metal visualizer without changing its call sites.
+@available(iOS 16, macCatalyst 16, *)
+struct ChatOrbView: View {
+    let state: ChatOrbState
+    let size: CGFloat
+    var theme: ChatWidgetTheme = .default
+
+    @State private var isPulsing = false
+
+    var body: some View {
+        Circle()
+            .fill(
+                LinearGradient(
+                    colors: [theme.orbSecondary, theme.orbPrimary],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .opacity(state == .disconnected ? 0.55 : 1)
+            .scaleEffect(isPulsing ? 1 : 0.92)
+            .frame(width: size, height: size)
+            // Only the breathing itself repeats; settling back is a one-shot.
+            .animation(isPulsing ? .easeInOut(duration: 0.9).repeatForever(autoreverses: true) : .easeOut(duration: 0.25), value: isPulsing)
+            .onAppear { isPulsing = state == .speaking || state == .connecting }
+            .onChange(of: state) { isPulsing = $0 == .speaking || $0 == .connecting }
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Views/ChatPopupView.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatPopupView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import SwiftUI
 
 /// The drawer: grabber, banner, header with the orb, transcript, composer.
@@ -26,7 +26,7 @@ struct ChatPopupView: View {
 
     /// The transcript is the only content worth the taller detent.
     private var isShowingTranscript: Bool {
-        vm.showsTranscript && !vm.messages.isEmpty
+        vm.showsTranscript && (!vm.messages.isEmpty || vm.endedConversation != nil)
     }
 
     var body: some View {
@@ -73,7 +73,12 @@ struct ChatPopupView: View {
             // Text-only opens straight into typing; wait out the drawer animation
             // so the keyboard reliably comes up.
             guard !vm.supportsVoice, vm.canShowTextInput else { return }
-            try? await Task.sleep(nanoseconds: 450_000_000)
+            do {
+                try await Task.sleep(nanoseconds: 450_000_000)
+            } catch {
+                return
+            }
+            guard !vm.supportsVoice, vm.canShowTextInput else { return }
             isInputFocused = true
         }
     }

--- a/Sources/ElevenLabsWidget/Views/ChatPopupView.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatPopupView.swift
@@ -1,0 +1,187 @@
+#if canImport(UIKit)
+import SwiftUI
+
+/// The drawer: grabber, banner, header with the orb, transcript, composer.
+@available(iOS 16, macCatalyst 16, *)
+struct ChatPopupView: View {
+    @ObservedObject var vm: ChatWidgetViewModel
+    @Binding var detent: ChatDrawerDetent
+    let onClose: () -> Void
+
+    @FocusState private var isInputFocused: Bool
+    @State private var dragOffset: CGFloat = 0
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
+
+    private static let cornerRadius: CGFloat = 32
+    private static let detentSpring = Animation.spring(response: 0.42, dampingFraction: 0.85)
+
+    private var strings: ChatWidgetStrings {
+        vm.widgetConfig.strings
+    }
+
+    /// A hero orb sized for portrait buries the composer in landscape.
+    private var heroOrbSize: CGFloat {
+        verticalSizeClass == .compact ? 72 : 128
+    }
+
+    /// The transcript is the only content worth the taller detent.
+    private var isShowingTranscript: Bool {
+        vm.showsTranscript && !vm.messages.isEmpty
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            grabber
+            if let banner = vm.banner {
+                ChatBannerView(
+                    banner: banner,
+                    strings: strings,
+                    theme: vm.widgetConfig.theme,
+                    onOpenSettings: vm.openSettings,
+                    onDismiss: vm.dismissBanner
+                )
+            }
+            header
+            Divider()
+            content
+            ChatInputBar(vm: vm, isInputFocused: $isInputFocused)
+                .padding(.horizontal, 10)
+                .padding(.top, 10)
+            Text(strings.mainLabel)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .padding(.vertical, 6)
+        }
+        .animation(.spring(response: 0.4, dampingFraction: 0.85), value: vm.banner)
+        .frame(maxWidth: .infinity)
+        .background {
+            UnevenRoundedRectangle(
+                topLeadingRadius: Self.cornerRadius,
+                topTrailingRadius: Self.cornerRadius,
+                style: .continuous
+            )
+            .fill(Color(.systemBackground))
+            .ignoresSafeArea(edges: .bottom)
+            .shadow(color: .black.opacity(0.18), radius: 24, y: -4)
+        }
+        .offset(y: dragOffset)
+        .contentShape(Rectangle())
+        .onTapGesture { isInputFocused = false }
+        .onChange(of: isShowingTranscript) { _ in syncDetentToTranscript() }
+        .onAppear(perform: syncDetentToTranscript)
+        .task {
+            // Text-only opens straight into typing; wait out the drawer animation
+            // so the keyboard reliably comes up.
+            guard !vm.supportsVoice, vm.canShowTextInput else { return }
+            try? await Task.sleep(nanoseconds: 450_000_000)
+            isInputFocused = true
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if !isShowingTranscript {
+            Spacer(minLength: 0)
+            orb(size: heroOrbSize)
+            Spacer(minLength: 0)
+        } else {
+            // A voice-only drawer has no composer to anchor it, so the orb stays
+            // visible above the transcript.
+            if !vm.canShowTextInput {
+                orb(size: heroOrbSize * 0.75).padding(.vertical, 12)
+            }
+            ChatTranscriptView(vm: vm)
+        }
+    }
+
+    private func orb(size: CGFloat) -> some View {
+        ChatOrbView(state: vm.orbState, size: size, theme: vm.widgetConfig.theme)
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            orb(size: 36)
+            Text(strings.title)
+                .font(.headline)
+            Spacer(minLength: 0)
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.secondary)
+                    .frame(width: 32, height: 32)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(strings.closeChatLabel)
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 12)
+    }
+
+    // MARK: - Drag
+
+    private var grabber: some View {
+        Capsule()
+            .fill(Color.secondary.opacity(0.3))
+            .frame(width: 48, height: 5)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+            .gesture(dragGesture)
+            .onTapGesture(perform: toggleDetent)
+            .accessibilityElement()
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel(detent == .compact ? strings.expandChatLabel : strings.collapseChatLabel)
+    }
+
+    /// Measured globally: the gesture sits inside a view this same drag offsets, so
+    /// a local space would feed the offset back into the translation and jitter.
+    private var dragGesture: some Gesture {
+        DragGesture(minimumDistance: 4, coordinateSpace: .global)
+            .onChanged { value in
+                let translation = value.translation.height
+                // Down follows the finger; up has no taller detent to reveal, so it
+                // only tugs.
+                dragOffset = translation >= 0 ? translation : rubberBand(translation)
+            }
+            .onEnded { value in
+                endDrag(predicted: value.predictedEndTranslation.height)
+            }
+    }
+
+    private func endDrag(predicted: CGFloat) {
+        // Keep the offset when closing so the exit continues from the finger
+        // rather than snapping back first.
+        switch (detent, predicted) {
+        case (.expanded, 220...): onClose()
+        case (.expanded, 100...): setDetent(.compact)
+        case (.compact, 100...): onClose()
+        case (.compact, ...(-60)): setDetent(.expanded)
+        default: withAnimation(Self.detentSpring) { dragOffset = 0 }
+        }
+    }
+
+    private func toggleDetent() {
+        setDetent(detent == .compact ? .expanded : .compact)
+    }
+
+    private func setDetent(_ target: ChatDrawerDetent) {
+        withAnimation(Self.detentSpring) {
+            detent = target
+            dragOffset = 0
+        }
+    }
+
+    /// Voice drawers open as a peek and grow once there is a transcript to read.
+    private func syncDetentToTranscript() {
+        guard vm.supportsVoice else { return }
+        setDetent(isShowingTranscript ? .expanded : .compact)
+    }
+
+    /// Diminishing travel for a drag with no detent behind it.
+    private func rubberBand(_ translation: CGFloat) -> CGFloat {
+        let limit: CGFloat = 56
+        return -limit * (1 - 1 / (abs(translation) / limit + 1))
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Views/ChatTranscriptView.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatTranscriptView.swift
@@ -1,0 +1,54 @@
+#if canImport(UIKit)
+import SwiftUI
+
+@available(iOS 16, macCatalyst 16, *)
+struct ChatTranscriptView: View {
+    @ObservedObject var vm: ChatWidgetViewModel
+
+    private static let endedFooterId = "transcript.ended"
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 10) {
+                    ForEach(vm.messages) { message in
+                        MessageBubble(message: message)
+                            .id(message.id)
+                    }
+                    if let ended = vm.endedConversation {
+                        endedFooter(ended).id(Self.endedFooterId)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            }
+            // Keyed on every message, so an insert or an edit above the last
+            // bubble scrolls too, not just a change to the newest text.
+            .onChange(of: vm.messages.map(\.content)) { _ in scrollToBottom(proxy) }
+            .onChange(of: vm.endedConversation) { _ in scrollToBottom(proxy) }
+        }
+    }
+
+    private func endedFooter(_ ended: ChatWidgetViewModel.EndedConversation) -> some View {
+        let strings = vm.widgetConfig.strings
+        return VStack(spacing: 2) {
+            Text(ended.endedByUser ? strings.userEndedConversation : strings.agentEndedConversation)
+                .font(.subheadline)
+            if let id = ended.id {
+                Text(String(format: strings.conversationIdFormat, id))
+                    .font(.caption.monospaced())
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .foregroundColor(.secondary)
+        .frame(maxWidth: .infinity)
+        .padding(.top, 8)
+    }
+
+    private func scrollToBottom(_ proxy: ScrollViewProxy) {
+        let last: AnyHashable? = vm.endedConversation == nil ? vm.messages.last?.id : Self.endedFooterId
+        guard let last else { return }
+        withAnimation(.easeOut(duration: 0.2)) { proxy.scrollTo(last, anchor: .bottom) }
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Views/ChatTranscriptView.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatTranscriptView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import SwiftUI
 
 @available(iOS 16, macCatalyst 16, *)

--- a/Sources/ElevenLabsWidget/Views/ChatWidget.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatWidget.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import ElevenLabs
 import SwiftUI
 import UIKit
@@ -16,6 +16,7 @@ public struct ChatWidget: View {
     @StateObject private var vm: ChatWidgetViewModel
     private let mode: WidgetConversationMode
     private let widgetConfig: ChatWidgetConfig
+    private let conversationConfig: ConversationConfig
     private let controller: ChatWidgetController?
     private let launcher: (() -> AnyView)?
     private let onClientToolCall: (@MainActor (ClientToolCallEvent) async -> ClientToolResultEvent)?
@@ -39,6 +40,7 @@ public struct ChatWidget: View {
     ) {
         self.mode = mode
         self.widgetConfig = widgetConfig
+        self.conversationConfig = conversationConfig
         self.controller = controller
         self.launcher = launcher
         self.onClientToolCall = onClientToolCall
@@ -55,10 +57,11 @@ public struct ChatWidget: View {
 
     public var body: some View {
         // This view is rebuilt on every host update while the view model
-        // survives, so the host's closures — credential mints and the tool
-        // handler — are handed over fresh here rather than left at whatever the
-        // first mount captured. Neither is published, so nothing is invalidated.
+        // survives, so session configuration and host closures are handed over
+        // fresh here rather than left at whatever the first mount captured.
+        // None are published, so these assignments invalidate nothing.
         vm.mode = mode
+        vm.conversationConfig = conversationConfig
         vm.onClientToolCall = onClientToolCall
         return ZStack(alignment: .bottomTrailing) {
             if vm.widgetConfig.showBackdrop {
@@ -82,10 +85,14 @@ public struct ChatWidget: View {
                     .transition(.scale.combined(with: .opacity))
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
         // Attaching seeds the controller's mirrors, so it has to happen outside a
         // view update — otherwise the host's controller invalidates the view that
         // is still being built.
         .task { if let controller { vm.attach(to: controller) } }
+        // The private client belongs to this visible widget. Once the host
+        // removes it, no UI remains to represent a live microphone or session.
+        .onDisappear(perform: vm.endConversation)
         // Published, so it can't be assigned mid-update like the mode above.
         .onChange(of: widgetConfig) { vm.widgetConfig = $0 }
     }

--- a/Sources/ElevenLabsWidget/Views/ChatWidget.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatWidget.swift
@@ -1,0 +1,117 @@
+#if canImport(UIKit)
+import ElevenLabs
+import SwiftUI
+import UIKit
+
+/// A drop-in chat widget: a launcher in the corner of your UI that opens a
+/// drawer with the agent conversation.
+///
+/// Overlay it on your own content, typically in a `ZStack`:
+///
+/// ```swift
+/// ChatWidget(mode: .voiceAndText(.publicAgent(id: "agent_id")))
+/// ```
+@available(iOS 16, macCatalyst 16, *)
+public struct ChatWidget: View {
+    @StateObject private var vm: ChatWidgetViewModel
+    private let mode: WidgetConversationMode
+    private let widgetConfig: ChatWidgetConfig
+    private let controller: ChatWidgetController?
+    private let launcher: (() -> AnyView)?
+    private let onClientToolCall: (@MainActor (ClientToolCallEvent) async -> ClientToolResultEvent)?
+
+    @State private var detent: ChatDrawerDetent = .expanded
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
+
+    /// - Parameters:
+    ///   - mode: How the user can talk to the agent, and the credentials each
+    ///     kind of session needs. Credentials are minted per session.
+    ///   - controller: Optional handle for driving the widget from the host.
+    ///   - launcher: Replaces the default orb launcher.
+    ///   - onClientToolCall: Handles client tool calls from the agent.
+    @MainActor public init(
+        mode: WidgetConversationMode,
+        widgetConfig: ChatWidgetConfig = .default,
+        conversationConfig: ConversationConfig = .init(),
+        controller: ChatWidgetController? = nil,
+        launcher: (() -> AnyView)? = nil,
+        onClientToolCall: (@MainActor (ClientToolCallEvent) async -> ClientToolResultEvent)? = nil
+    ) {
+        self.mode = mode
+        self.widgetConfig = widgetConfig
+        self.controller = controller
+        self.launcher = launcher
+        self.onClientToolCall = onClientToolCall
+        // Built inside the autoclosure so SwiftUI only creates it once, rather
+        // than on every re-init of this view.
+        _vm = StateObject(wrappedValue: ChatWidgetViewModel(
+            mode: mode,
+            widgetConfig: widgetConfig,
+            client: ConversationClient(),
+            conversationConfig: conversationConfig,
+            onClientToolCall: onClientToolCall
+        ))
+    }
+
+    public var body: some View {
+        // This view is rebuilt on every host update while the view model
+        // survives, so the host's closures — credential mints and the tool
+        // handler — are handed over fresh here rather than left at whatever the
+        // first mount captured. Neither is published, so nothing is invalidated.
+        vm.mode = mode
+        vm.onClientToolCall = onClientToolCall
+        return ZStack(alignment: .bottomTrailing) {
+            if vm.widgetConfig.showBackdrop {
+                // Always mounted so hit-testing switches off the instant we close;
+                // a removal transition would keep swallowing taps while fading out.
+                Color.black
+                    .opacity(vm.isOpen ? 0.2 : 0)
+                    .ignoresSafeArea()
+                    .allowsHitTesting(vm.isOpen)
+                    .onTapGesture(perform: vm.close)
+            }
+
+            if vm.isOpen {
+                ChatPopupView(vm: vm, detent: $detent, onClose: vm.close)
+                    .frame(maxHeight: detent == .compact ? compactDrawerHeight : .infinity)
+                    .padding(.top, detent == .expanded ? 64 : 0)
+                    .transition(.move(edge: .bottom))
+            } else {
+                launcherView
+                    .padding(16)
+                    .transition(.scale.combined(with: .opacity))
+            }
+        }
+        // Attaching seeds the controller's mirrors, so it has to happen outside a
+        // view update — otherwise the host's controller invalidates the view that
+        // is still being built.
+        .task { if let controller { vm.attach(to: controller) } }
+        // Published, so it can't be assigned mid-update like the mode above.
+        .onChange(of: widgetConfig) { vm.widgetConfig = $0 }
+    }
+
+    /// Half height reads as a peek in portrait, but in landscape it leaves the
+    /// composer fighting the keyboard, so the compact detent is nearly full there.
+    private var compactDrawerHeight: CGFloat {
+        let screenHeight = UIScreen.main.bounds.height
+        guard verticalSizeClass != .compact else { return screenHeight * 0.92 }
+        return screenHeight * (vm.canShowTextInput ? 0.5 : 0.4)
+    }
+
+    @ViewBuilder
+    private var launcherView: some View {
+        if let launcher {
+            Button(action: vm.toggleOpen) { launcher() }
+                .buttonStyle(.plain)
+                .accessibilityLabel(vm.widgetConfig.strings.openChatLabel)
+        } else {
+            FloatingChatButton(
+                orbState: vm.orbState,
+                theme: vm.widgetConfig.theme,
+                accessibilityLabel: vm.widgetConfig.strings.openChatLabel,
+                onTap: vm.toggleOpen
+            )
+        }
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Views/FloatingChatButton.swift
+++ b/Sources/ElevenLabsWidget/Views/FloatingChatButton.swift
@@ -1,0 +1,21 @@
+#if canImport(UIKit)
+import SwiftUI
+
+/// Default launcher: a mini orb in the corner of the host UI.
+@available(iOS 16, macCatalyst 16, *)
+struct FloatingChatButton: View {
+    let orbState: ChatOrbState
+    let theme: ChatWidgetTheme
+    let accessibilityLabel: String
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            ChatOrbView(state: orbState, size: 58, theme: theme)
+                .shadow(color: .black.opacity(0.18), radius: 10, y: 4)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Views/FloatingChatButton.swift
+++ b/Sources/ElevenLabsWidget/Views/FloatingChatButton.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import SwiftUI
 
 /// Default launcher: a mini orb in the corner of the host UI.

--- a/Sources/ElevenLabsWidget/Views/MessageBubble.swift
+++ b/Sources/ElevenLabsWidget/Views/MessageBubble.swift
@@ -1,0 +1,24 @@
+#if canImport(UIKit)
+import SwiftUI
+
+@available(iOS 16, macCatalyst 16, *)
+struct MessageBubble: View {
+    let message: ChatMessage
+
+    var body: some View {
+        HStack {
+            if message.role == .user { Spacer(minLength: 40) }
+            Text(message.content)
+                .font(.body)
+                .foregroundColor(message.role == .user ? .white : .primary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(message.role == .user ? Color.black : Color(.secondarySystemBackground))
+                )
+            if message.role == .agent { Spacer(minLength: 40) }
+        }
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Views/MessageBubble.swift
+++ b/Sources/ElevenLabsWidget/Views/MessageBubble.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+#if os(iOS)
 import SwiftUI
 
 @available(iOS 16, macCatalyst 16, *)


### PR DESCRIPTION
## Summary

First slice of the widget port. Adds `ElevenLabsWidget` as a second product in the package and an `Examples/DemoApp` that uses it, so everything after this is reviewable against something you can actually run.

- Widget: floating launcher, drawer, transcript, composer, mic mute, a static placeholder orb.
- `ChatWidgetController`: the host's handle on the widget — mirrors state (`state`, `isOpen`, `isMicMuted`, `conversationId`, `messageCount`) and forwards commands (`open`, `close`, `startConversation`, `sendMessage`, `setMicMuted`, ...).
- `ChatWidgetConfig` / `ChatWidgetStrings` / `ChatWidgetTheme` for behavior, copy, and colors.
- `Examples/DemoApp`: a real-estate search form driven by an `update_real_estate_search` client tool, plus buttons that drive the widget through the controller.

Everything is `#if canImport(UIKit)` and `@available(iOS 16, ...)`, so the SDK keeps its iOS 13 floor and `swift build` on macOS compiles the widget to an empty module.

## Not in this PR

The real orb (next), conversation modes, drawer polish, markdown transcript, error banner, attachments, feedback, terms, and MCP approval all land as their own slices on top.

## Test plan

- [x] `swift build`, `swift test`, `swiftformat . --strict`
- [x] `xcodebuild` of `Examples/DemoApp` for the iOS simulator
- [x] Manual: launcher opens the drawer, text conversation round-trips, client tool fills the form

Note that repo CI only builds PRs targeting `main`, so this stack gets SwiftFormat but no build job.