### PR TITLE
feat: drive the widget orb from mic and agent audio

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,15 @@ let package = Package(
             name: "ElevenLabsWidget",
             dependencies: [
                 "ElevenLabs"
+            ],
+            resources: [
+                .process("Resources/OrbShader.metal")
+            ]
+        ),
+        .testTarget(
+            name: "ElevenLabsWidgetTests",
+            dependencies: [
+                "ElevenLabsWidget"
             ]
         ),
         .testTarget(

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -45,6 +45,15 @@ let package = Package(
             name: "ElevenLabsWidget",
             dependencies: [
                 "ElevenLabs"
+            ],
+            resources: [
+                .process("Resources/OrbShader.metal")
+            ]
+        ),
+        .testTarget(
+            name: "ElevenLabsWidgetTests",
+            dependencies: [
+                "ElevenLabsWidget"
             ]
         ),
         .testTarget(

--- a/Package@swift-6.2.swift
+++ b/Package@swift-6.2.swift
@@ -45,6 +45,15 @@ let package = Package(
             name: "ElevenLabsWidget",
             dependencies: [
                 "ElevenLabs"
+            ],
+            resources: [
+                .process("Resources/OrbShader.metal")
+            ]
+        ),
+        .testTarget(
+            name: "ElevenLabsWidgetTests",
+            dependencies: [
+                "ElevenLabsWidget"
             ]
         ),
         .testTarget(

--- a/Sources/ElevenLabsWidget/Audio/ConversationAudioLevelMonitor.swift
+++ b/Sources/ElevenLabsWidget/Audio/ConversationAudioLevelMonitor.swift
@@ -1,0 +1,62 @@
+import Accelerate
+@preconcurrency import AVFoundation
+import ElevenLabs
+
+/// Tracks a normalized loudness level for one conversation audio stream.
+///
+/// Pull-based: `didReceive` runs on the audio thread and only holds the loudest
+/// level seen. Reading drains it, which is also what paces the decay, so the
+/// level keeps falling once a stream goes quiet and stops delivering buffers.
+final class ConversationAudioLevelMonitor: ConversationAudioObserver, @unchecked Sendable {
+    /// Fraction of the level kept per read: fast attack, slow release.
+    private static let release: Float = 0.75
+
+    private let lock = NSLock()
+    private var storedLevel: Float = 0
+    /// Only touched from the audio thread, which delivers buffers serially.
+    private var scratch: [Float] = []
+
+    /// The loudest level since the last read, leaving one release step behind.
+    func sample() -> Float {
+        lock.withLock {
+            defer { storedLevel *= Self.release }
+            return storedLevel
+        }
+    }
+
+    func didReceive(_ buffer: AVAudioPCMBuffer) {
+        guard let level = normalizedRMS(of: buffer) else { return }
+        lock.withLock { storedLevel = max(level, storedLevel) }
+    }
+
+    func reset() {
+        lock.withLock { storedLevel = 0 }
+    }
+
+    /// RMS of the first channel, mapped from the top 60 dB of headroom onto 0...1.
+    private func normalizedRMS(of buffer: AVAudioPCMBuffer) -> Float? {
+        let frames = Int(buffer.frameLength)
+        guard frames > 0 else { return nil }
+        let stride = buffer.format.isInterleaved ? vDSP_Stride(buffer.format.channelCount) : 1
+
+        var rms: Float = 0
+        if let channel = buffer.floatChannelData?[0] {
+            vDSP_rmsqv(channel, stride, &rms, vDSP_Length(frames))
+        } else if let channel = buffer.int16ChannelData?[0] {
+            // Grown, never reallocated per buffer: this is the audio thread.
+            if scratch.count < frames { scratch = [Float](repeating: 0, count: frames) }
+            scratch.withUnsafeMutableBufferPointer { floats in
+                guard let samples = floats.baseAddress else { return }
+                vDSP_vflt16(channel, stride, samples, 1, vDSP_Length(frames))
+                var scale = 1 / Float(Int16.max)
+                vDSP_vsmul(samples, 1, &scale, samples, 1, vDSP_Length(frames))
+                vDSP_rmsqv(samples, 1, &rms, vDSP_Length(frames))
+            }
+        } else {
+            return nil
+        }
+
+        let decibels = 20 * log10(max(rms, 0.000_001))
+        return min(max((decibels + 60) / 60, 0), 1)
+    }
+}

--- a/Sources/ElevenLabsWidget/Audio/ConversationAudioLevelMonitor.swift
+++ b/Sources/ElevenLabsWidget/Audio/ConversationAudioLevelMonitor.swift
@@ -12,8 +12,9 @@ final class ConversationAudioLevelMonitor: ConversationAudioObserver, @unchecked
     private static let release: Float = 0.75
 
     private let lock = NSLock()
+    private let scratchLock = NSLock()
     private var storedLevel: Float = 0
-    /// Only touched from the audio thread, which delivers buffers serially.
+    /// Reused for Int16 conversion.
     private var scratch: [Float] = []
 
     /// The loudest level since the last read, leaving one release step behind.
@@ -43,14 +44,16 @@ final class ConversationAudioLevelMonitor: ConversationAudioObserver, @unchecked
         if let channel = buffer.floatChannelData?[0] {
             vDSP_rmsqv(channel, stride, &rms, vDSP_Length(frames))
         } else if let channel = buffer.int16ChannelData?[0] {
-            // Grown, never reallocated per buffer: this is the audio thread.
-            if scratch.count < frames { scratch = [Float](repeating: 0, count: frames) }
-            scratch.withUnsafeMutableBufferPointer { floats in
-                guard let samples = floats.baseAddress else { return }
-                vDSP_vflt16(channel, stride, samples, 1, vDSP_Length(frames))
-                var scale = 1 / Float(Int16.max)
-                vDSP_vsmul(samples, 1, &scale, samples, 1, vDSP_Length(frames))
-                vDSP_rmsqv(samples, 1, &rms, vDSP_Length(frames))
+            scratchLock.withLock {
+                // Grown, never reallocated per buffer: this is the audio thread.
+                if scratch.count < frames { scratch = [Float](repeating: 0, count: frames) }
+                scratch.withUnsafeMutableBufferPointer { floats in
+                    guard let samples = floats.baseAddress else { return }
+                    vDSP_vflt16(channel, stride, samples, 1, vDSP_Length(frames))
+                    var scale = 1 / Float(Int16.max)
+                    vDSP_vsmul(samples, 1, &scale, samples, 1, vDSP_Length(frames))
+                    vDSP_rmsqv(samples, 1, &rms, vDSP_Length(frames))
+                }
             }
         } else {
             return nil

--- a/Sources/ElevenLabsWidget/Audio/OrbAudioLevels.swift
+++ b/Sources/ElevenLabsWidget/Audio/OrbAudioLevels.swift
@@ -1,0 +1,58 @@
+import Combine
+import Foundation
+
+/// Samples the mic and agent level monitors at a display-friendly rate.
+///
+/// The monitors are updated at PCM rate on the audio thread; publishing from
+/// there would re-render SwiftUI thousands of times a second, so the levels are
+/// polled on a timer while a conversation is live instead.
+@MainActor
+final class OrbAudioLevels: ObservableObject {
+    @Published private(set) var input: Float = 0
+    @Published private(set) var output: Float = 0
+
+    let micMonitor = ConversationAudioLevelMonitor()
+    let agentMonitor = ConversationAudioLevelMonitor()
+
+    private static let interval: TimeInterval = 1.0 / 30
+    private var timer: Timer?
+
+    var isActive: Bool = false {
+        didSet {
+            guard isActive != oldValue else { return }
+            isActive ? start() : stop()
+        }
+    }
+
+    deinit { timer?.invalidate() }
+
+    private func start() {
+        // Clears anything the audio thread wrote after the last stop, which would
+        // otherwise surface as leftover loudness from the previous call.
+        micMonitor.reset()
+        agentMonitor.reset()
+        let timer = Timer(timeInterval: Self.interval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.sample() }
+        }
+        // Common mode, so the levels keep updating while the transcript scrolls.
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    private func stop() {
+        timer?.invalidate()
+        timer = nil
+        micMonitor.reset()
+        agentMonitor.reset()
+        input = 0
+        output = 0
+    }
+
+    /// Only publishes on change, so a silent conversation doesn't redraw the orb.
+    private func sample() {
+        let mic = micMonitor.sample()
+        let agent = agentMonitor.sample()
+        if mic != input { input = mic }
+        if agent != output { output = agent }
+    }
+}

--- a/Sources/ElevenLabsWidget/Rendering/Orb.swift
+++ b/Sources/ElevenLabsWidget/Rendering/Orb.swift
@@ -1,0 +1,288 @@
+// Ported from ElevenLabs components-swift (OrbVisualizer.swift), trimmed to the
+// volume-driven orb; the LiveKit track-based visualizer is not carried over.
+
+#if canImport(UIKit)
+import Foundation
+import MetalKit
+import simd
+import SwiftUI
+import UIKit
+
+/// CPU-side uniforms must match `OrbUniforms` in `OrbShader.metal` byte‑for‑byte.
+/// Stride = 96 bytes.
+struct OrbUniforms {
+    var time: Float = 0
+    var animation: Float = 0
+    var inverted: Float = 0
+    var _pad0: Float = 0 // 16‑byte align
+    var offsets: simd_float8 = .zero // only first 7 used
+    var color1: simd_float4 = .zero
+    var color2: simd_float4 = .zero
+    var inputVolume: Float = 0
+    var outputVolume: Float = 0
+    var _pad1: SIMD2<Float> = .zero // to 96 bytes
+
+    init() {}
+}
+
+/// Convert SwiftUI `Color` -> linear‑space simd_float4.
+@inline(__always)
+@available(iOS 14, macCatalyst 14, *)
+private func colorToSIMD4(_ color: Color) -> simd_float4 {
+    let ui = UIColor(color)
+    var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 1
+    ui.getRed(&r, green: &g, blue: &b, alpha: &a)
+    func sRGBToLinear(_ v: CGFloat) -> Float {
+        if v <= 0.04045 { return Float(v / 12.92) }
+        return Float(pow((v + 0.055) / 1.055, 2.4))
+    }
+    return .init(sRGBToLinear(r), sRGBToLinear(g), sRGBToLinear(b), Float(a))
+}
+
+/// Shared Metal renderer backing the SwiftUI representables.
+@available(iOS 14, macCatalyst 14, *)
+class MetalOrbRenderer: NSObject, MTKViewDelegate {
+    private let device: MTLDevice
+    private let commandQueue: MTLCommandQueue
+    private var pipeline: MTLRenderPipelineState!
+    private var vertexBuffer: MTLBuffer!
+
+    private var animationTime: Float = 0
+    /// Wall-clock-driven time fed to the shader. Unlike `CACurrentMediaTime`
+    /// it only advances while the orb is active, so a `.disconnected` orb
+    /// freezes instead of swirling as if it were live.
+    private var displayTime: Float = 0
+    private var lastDrawTime: CFTimeInterval = CACurrentMediaTime()
+
+    private var uniforms = OrbUniforms()
+    private var randomOffsets: [Float] = []
+    private var currentAgentState: VisualizerAgentState = .unknown
+
+    // MARK: - Init
+
+    override init() {
+        guard let d = MTLCreateSystemDefaultDevice(), let q = d.makeCommandQueue() else {
+            fatalError("Metal not available")
+        }
+        device = d
+        commandQueue = q
+        super.init()
+        generateRandomOffsets()
+        buildBuffers()
+        buildPipeline()
+    }
+
+    // MARK: - Public updaters
+
+    func updateColors(color1: Color, color2: Color) {
+        uniforms.color1 = colorToSIMD4(color1)
+        uniforms.color2 = colorToSIMD4(color2)
+    }
+
+    func updateVolumes(input: Float, output: Float) {
+        uniforms.inputVolume = max(0, min(1, input))
+        uniforms.outputVolume = max(0, min(1, output))
+    }
+
+    func updateAgentState(_ state: VisualizerAgentState) {
+        // No longer inverting colors for thinking state
+        uniforms.inverted = 0
+        currentAgentState = state
+    }
+
+    // MARK: - MTKViewDelegate
+
+    func mtkView(_: MTKView, drawableSizeWillChange _: CGSize) {}
+
+    func draw(in view: MTKView) {
+        guard let drawable = view.currentDrawable,
+              let rpd = view.currentRenderPassDescriptor,
+              let cmd = commandQueue.makeCommandBuffer(),
+              let enc = cmd.makeRenderCommandEncoder(descriptor: rpd) else { return }
+
+        let now = CACurrentMediaTime()
+        let fps = max(view.preferredFramesPerSecond, 1)
+        // Capped at one frame: an idle orb stops drawing, and the gap must not
+        // land on the clock as a jump when the next call resumes it.
+        let dt = min(Float(now - lastDrawTime), 1 / Float(fps))
+        lastDrawTime = now
+
+        // A disconnected orb is idle: freeze both animation clocks so it stops
+        // swirling (otherwise it looks "active" / live even after a call ends).
+        let isIdle = currentAgentState == .disconnected
+        if !isIdle {
+            // Slow down animation when thinking (0.02x speed instead of 0.1x)
+            let animationSpeed: Float = currentAgentState == .thinking ? 0.02 : 0.1
+            animationTime += (1.0 / Float(fps)) * animationSpeed
+            displayTime += dt
+        }
+        uniforms.time = displayTime
+        uniforms.animation = animationTime
+        uniforms.offsets = simd_float8(randomOffsets + [0])
+
+        enc.setRenderPipelineState(pipeline)
+        enc.setVertexBuffer(vertexBuffer, offset: 0, index: 0)
+
+        var u = uniforms
+        if isIdle {
+            // Don't let any residual level keep the idle orb pulsing.
+            u.inputVolume = 0
+            u.outputVolume = 0
+        }
+        enc.setFragmentBytes(&u, length: MemoryLayout<OrbUniforms>.stride, index: 0)
+
+        enc.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+        enc.endEncoding()
+        cmd.present(drawable)
+        cmd.commit()
+    }
+
+    // MARK: - Private
+
+    private func generateRandomOffsets() {
+        randomOffsets = (0 ..< 7).map { _ in Float.random(in: 0 ... (Float.pi * 2)) }
+    }
+
+    private func buildBuffers() {
+        // full‑screen quad
+        let verts: [Float] = [
+            -1, 1,
+            -1, -1,
+            1, 1,
+            1, -1
+        ]
+        vertexBuffer = device.makeBuffer(bytes: verts, length: verts.count * MemoryLayout<Float>.size, options: [])
+    }
+
+    private func buildPipeline() {
+        // Try to load the Metal library from various sources
+        var lib: MTLLibrary?
+
+        // For Swift Package Manager, try Bundle.module first (contains package resources)
+        #if SWIFT_PACKAGE
+        lib = try? device.makeDefaultLibrary(bundle: Bundle.module)
+        #endif
+
+        // Try default library (works when Metal files are in the main target)
+        if lib == nil {
+            lib = device.makeDefaultLibrary()
+        }
+
+        // If that fails, try the class bundle
+        if lib == nil {
+            lib = try? device.makeDefaultLibrary(bundle: Bundle(for: type(of: self)))
+        }
+
+        // If not found, try the main bundle
+        if lib == nil {
+            lib = try? device.makeDefaultLibrary(bundle: .main)
+        }
+
+        guard let library = lib else {
+            fatalError("Unable to load Metal library – ensure OrbShader.metal is included in the target")
+        }
+
+        guard let vfn = library.makeFunction(name: "orbVertexShader"),
+              let ffn = library.makeFunction(name: "orbFragmentShader")
+        else {
+            fatalError("Unable to find shader functions in Metal library")
+        }
+
+        let desc = MTLRenderPipelineDescriptor()
+        desc.vertexFunction = vfn
+        desc.fragmentFunction = ffn
+        desc.colorAttachments[0].pixelFormat = .bgra8Unorm
+
+        do {
+            pipeline = try device.makeRenderPipelineState(descriptor: desc)
+        } catch {
+            fatalError("Orb pipeline creation failed: \(error)")
+        }
+    }
+}
+
+@available(iOS 14, macCatalyst 14, *)
+struct OrbMetalView: UIViewRepresentable {
+    var color1: Color
+    var color2: Color
+    var inputVolume: Float
+    var outputVolume: Float
+    var agentState: VisualizerAgentState
+
+    func makeUIView(context: Context) -> MTKView {
+        let view = MTKView()
+        view.device = MTLCreateSystemDefaultDevice()
+        view.delegate = context.coordinator
+        configure(view: view)
+        context.coordinator.updateAll(color1: color1, color2: color2, input: inputVolume, output: outputVolume, state: agentState)
+        return view
+    }
+
+    func updateUIView(_ view: MTKView, context: Context) {
+        context.coordinator.updateAll(color1: color1, color2: color2, input: inputVolume, output: outputVolume, state: agentState)
+        setIdle(isIdle, on: view)
+    }
+
+    /// A disconnected, silent orb renders a still frame, so the launcher isn't
+    /// driving the GPU at 60fps while it sits in the host's UI.
+    private var isIdle: Bool {
+        agentState == .disconnected && inputVolume == 0 && outputVolume == 0
+    }
+
+    private func setIdle(_ idle: Bool, on view: MTKView) {
+        view.isPaused = idle
+        // On demand rather than never, so layout changes still get a frame.
+        view.enableSetNeedsDisplay = idle
+        if idle { view.setNeedsDisplay() }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    private func configure(view: MTKView) {
+        view.framebufferOnly = false
+        view.isPaused = false
+        view.enableSetNeedsDisplay = false
+        view.preferredFramesPerSecond = 60
+        view.clearColor = .init(red: 0, green: 0, blue: 0, alpha: 0)
+        view.colorPixelFormat = .bgra8Unorm
+        view.autoResizeDrawable = true
+    }
+
+    final class Coordinator: MetalOrbRenderer {
+        func updateAll(color1: Color, color2: Color, input: Float, output: Float, state: VisualizerAgentState) {
+            updateColors(color1: color1, color2: color2)
+            updateVolumes(input: input, output: output)
+            updateAgentState(state)
+        }
+    }
+}
+
+@available(iOS 14, macCatalyst 14, *)
+struct Orb: View {
+    var color1: Color
+    var color2: Color
+    var inputVolume: Float
+    var outputVolume: Float
+    var agentState: VisualizerAgentState = .unknown
+
+    var body: some View {
+        GeometryReader { geo in
+            let side = max(1, min(geo.size.width, geo.size.height))
+            OrbMetalView(
+                color1: color1,
+                color2: color2,
+                inputVolume: inputVolume,
+                outputVolume: outputVolume,
+                agentState: agentState
+            )
+            .frame(width: side, height: side)
+            .clipShape(Circle())
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityLabel(Text("Orb visualizer"))
+        }
+        .aspectRatio(1, contentMode: .fit)
+    }
+}
+#endif

--- a/Sources/ElevenLabsWidget/Rendering/VisualizerAgentState.swift
+++ b/Sources/ElevenLabsWidget/Rendering/VisualizerAgentState.swift
@@ -1,0 +1,23 @@
+#if canImport(UIKit)
+import Foundation
+
+/// A richer agent state enum specifically for visualizer animations.
+/// This enum preserves the full set of states needed for detailed visual feedback,
+/// independent of the simplified SDK's `AgentState` enum.
+enum VisualizerAgentState: Sendable, Equatable {
+    /// Agent is connecting to the session
+    case connecting
+    /// Agent is initializing
+    case initializing
+    /// Agent is listening to user input
+    case listening
+    /// Agent is processing/thinking
+    case thinking
+    /// Agent is speaking
+    case speaking
+    /// Agent is disconnected
+    case disconnected
+    /// Unknown or unspecified state
+    case unknown
+}
+#endif

--- a/Sources/ElevenLabsWidget/Resources/OrbShader.metal
+++ b/Sources/ElevenLabsWidget/Resources/OrbShader.metal
@@ -1,0 +1,203 @@
+#include <metal_stdlib>
+using namespace metal;
+
+constant float PI = 3.14159265358979323846;
+
+struct VertexOut {
+    float4 position [[position]];
+    float2 uv;
+};
+
+struct OrbUniforms {
+    float time;
+    float animation;
+    float inverted;
+    float _pad0; // padding to 16 bytes alignment
+    float offsets[8]; // 8 offsets for alignment
+    float4 color1;
+    float4 color2;
+    float inputVolume;
+    float outputVolume;
+    float2 _pad1; // 8 bytes padding to reach 96 bytes
+};
+
+vertex VertexOut orbVertexShader(uint vertexID [[vertex_id]],
+                                 constant float2* vertices [[buffer(0)]]) {
+    VertexOut out;
+    float2 pos = vertices[vertexID];
+    out.position = float4(pos, 0.0, 1.0);
+    out.uv = pos * 0.5 + 0.5; // Convert from [-1,1] to [0,1]
+    return out;
+}
+
+float2 hash2(float2 p) {
+    return fract(sin(float2(dot(p, float2(127.1, 311.7)), dot(p, float2(269.5, 183.3)))) * 43758.5453);
+}
+
+float noise2D(float2 p) {
+    float2 i = floor(p);
+    float2 f = fract(p);
+    
+    float2 u = f * f * (3.0 - 2.0 * f);
+    float n = mix(
+        mix(dot(hash2(i + float2(0.0, 0.0)), f - float2(0.0, 0.0)),
+            dot(hash2(i + float2(1.0, 0.0)), f - float2(1.0, 0.0)), u.x),
+        mix(dot(hash2(i + float2(0.0, 1.0)), f - float2(0.0, 1.0)),
+            dot(hash2(i + float2(1.0, 1.0)), f - float2(1.0, 1.0)), u.x),
+        u.y
+    );
+
+    return 0.5 + 0.5 * n;
+}
+
+float perlinTexture(float2 uv) {
+    return noise2D(uv * 8.0);
+}
+
+bool drawOval(float2 polarUv, float2 polarCenter, float a, float b, bool reverseGradient, float softness, thread float4& color) {
+    float2 p = polarUv - polarCenter;
+    float oval = (p.x * p.x) / (a * a) + (p.y * p.y) / (b * b);
+    
+    float edge = smoothstep(1.0, 1.0 - softness, oval);
+    
+    if (edge > 0.0) {
+        float gradient = reverseGradient ? (1.0 - (p.x / a + 1.0) / 2.0) : ((p.x / a + 1.0) / 2.0);
+        color = float4(float3(gradient), min(1.2 * edge, 1.0));
+        return true;
+    }
+    return false;
+}
+
+float3 colorRamp(float grayscale, float3 color1, float3 color2, float3 color3, float3 color4) {
+    if (grayscale < 0.33) {
+        return mix(color1, color2, grayscale * 3.0);
+    } else if (grayscale < 0.66) {
+        return mix(color2, color3, (grayscale - 0.33) * 3.0);
+    } else {
+        return mix(color3, color4, (grayscale - 0.66) * 3.0);
+    }
+}
+
+float sharpRing(float3 decomposed, float time) {
+    float ringStart = 1.0;
+    float ringWidth = 0.5;
+    float noiseScale = 5.0;
+
+    float noise = mix(
+        noise2D(float2(decomposed.x, time) * noiseScale),
+        noise2D(float2(decomposed.y, time) * noiseScale),
+        decomposed.z
+    );
+
+    noise = (noise - 0.5) * 4.0;
+
+    return ringStart + noise * ringWidth * 1.5;
+}
+
+float smoothRing(float3 decomposed, float time) {
+    float ringStart = 0.9;
+    float ringWidth = 0.3;
+    float noiseScale = 6.0;
+
+    float noise = mix(
+        noise2D(float2(decomposed.x, time) * noiseScale),
+        noise2D(float2(decomposed.y, time) * noiseScale),
+        decomposed.z
+    );
+
+    noise = (noise - 0.5) * 8.0;
+
+    return ringStart + noise * ringWidth;
+}
+
+float flow(float3 decomposed, float time) {
+    return mix(
+        perlinTexture(float2(time, decomposed.x / 2.0)),
+        perlinTexture(float2(time, decomposed.y / 2.0)),
+        decomposed.z
+    );
+}
+
+fragment float4 orbFragmentShader(VertexOut in [[stage_in]],
+                                  constant OrbUniforms& uniforms [[buffer(0)]]) {
+    
+    float2 uv = in.uv * 2.0 - 1.0;
+
+    float radius = length(uv);
+    float theta = atan2(uv.y, uv.x);
+    if (theta < 0.0) theta += 2.0 * PI;
+
+    float3 decomposed = float3(
+        theta / (2.0 * PI),
+        fmod(theta / (2.0 * PI) + 0.5, 1.0) + 1.0,
+        abs(theta / PI - 1.0)
+    );
+
+    float noise = flow(decomposed, radius * 0.03 - uniforms.animation * 0.2) - 0.5;
+    theta += noise * mix(0.5, 1.0, uniforms.outputVolume);
+
+    float4 color = float4(1.0, 1.0, 1.0, 1.0);
+
+    float originalCenters[7] = {0.0, 0.5 * PI, 1.0 * PI, 1.5 * PI, 2.0 * PI, 2.5 * PI, 3.0 * PI};
+
+    float centers[7];
+    for (int i = 0; i < 7; i++) {
+        centers[i] = originalCenters[i] + 0.5 * sin(uniforms.time / 20.0 + uniforms.offsets[i]);
+    }
+
+    float a, b;
+    float4 ovalColor;
+
+    for (int i = 0; i < 7; i++) {
+        float noise = perlinTexture(float2(fmod(centers[i] + uniforms.time * 0.05, 1.0), 0.5));
+        a = 0.5 + noise * 0.5; // Increased variance: goes from 0.0 to 1.0
+        b = noise * mix(4.5, 3.0, uniforms.inputVolume); // Tall semi-minor axis
+        bool reverseGradient = (i % 2 == 1); // Reverse gradient for every second oval
+
+        // Calculate the distance in polar coordinates
+        float distTheta = min(
+            abs(theta - centers[i]),
+            min(
+                abs(theta + 2.0 * PI - centers[i]),
+                abs(theta - 2.0 * PI - centers[i])
+            )
+        );
+        float distRadius = radius;
+
+        float softness = 0.4; // Controls edge softness
+
+        if (drawOval(float2(distTheta, distRadius), float2(0.0, 0.0), a, b, reverseGradient, softness, ovalColor)) {
+            color.rgb = mix(color.rgb, ovalColor.rgb, ovalColor.a);
+        }
+    }
+    
+    float ringRadius1 = sharpRing(decomposed, uniforms.time * 0.1);
+    float ringRadius2 = smoothRing(decomposed, uniforms.time * 0.1);
+    
+    float inputRadius1 = radius + uniforms.inputVolume * 0.3;
+    float inputRadius2 = radius + uniforms.inputVolume * 0.2;
+    float opacity1 = mix(0.3, 0.8, uniforms.inputVolume);
+    float opacity2 = mix(0.25, 0.6, uniforms.inputVolume);
+
+    float ringAlpha1 = (inputRadius2 >= ringRadius1) ? opacity1 : 0.0;
+    float ringAlpha2 = smoothstep(ringRadius2 - 0.05, ringRadius2 + 0.05, inputRadius1) * opacity2;
+    
+    float totalRingAlpha = max(ringAlpha1, ringAlpha2);
+    
+    float3 ringColor = float3(1.0);
+    color.rgb = 1.0 - (1.0 - color.rgb) * (1.0 - ringColor * totalRingAlpha);
+
+    float3 color1 = float3(0.0, 0.0, 0.0); // Black
+    float3 color2 = uniforms.color1.xyz; // Darker Color
+    float3 color3 = uniforms.color2.xyz; // Lighter Color
+    float3 color4 = float3(1.0, 1.0, 1.0); // White
+
+    // Convert grayscale color to the color ramp
+    float luminance = mix(color.r, 1.0 - color.r, uniforms.inverted);
+    color.rgb = colorRamp(luminance, color1, color2, color3, color4);
+
+    // Always fully opaque for the orb
+    color.a = 1.0;
+
+    return color;
+}

--- a/Sources/ElevenLabsWidget/Resources/OrbShader.metal
+++ b/Sources/ElevenLabsWidget/Resources/OrbShader.metal
@@ -58,7 +58,7 @@ bool drawOval(float2 polarUv, float2 polarCenter, float a, float b, bool reverse
     float2 p = polarUv - polarCenter;
     float oval = (p.x * p.x) / (a * a) + (p.y * p.y) / (b * b);
     
-    float edge = smoothstep(1.0, 1.0 - softness, oval);
+    float edge = 1.0 - smoothstep(1.0 - softness, 1.0, oval);
     
     if (edge > 0.0) {
         float gradient = reverseGradient ? (1.0 - (p.x / a + 1.0) / 2.0) : ((p.x / a + 1.0) / 2.0);
@@ -134,7 +134,9 @@ fragment float4 orbFragmentShader(VertexOut in [[stage_in]],
     );
 
     float noise = flow(decomposed, radius * 0.03 - uniforms.animation * 0.2) - 0.5;
-    theta += noise * mix(0.5, 1.0, uniforms.outputVolume);
+    float inputResponse = sqrt(uniforms.inputVolume);
+    float angularStrength = mix(0.1, 6.0, inputResponse);
+    theta += noise * angularStrength;
 
     float4 color = float4(1.0, 1.0, 1.0, 1.0);
 
@@ -151,7 +153,7 @@ fragment float4 orbFragmentShader(VertexOut in [[stage_in]],
     for (int i = 0; i < 7; i++) {
         float noise = perlinTexture(float2(fmod(centers[i] + uniforms.time * 0.05, 1.0), 0.5));
         a = 0.5 + noise * 0.5; // Increased variance: goes from 0.0 to 1.0
-        b = noise * mix(4.5, 3.0, uniforms.inputVolume); // Tall semi-minor axis
+        b = noise * mix(4.5, 3.0, uniforms.outputVolume); // Tall semi-minor axis
         bool reverseGradient = (i % 2 == 1); // Reverse gradient for every second oval
 
         // Calculate the distance in polar coordinates
@@ -174,13 +176,13 @@ fragment float4 orbFragmentShader(VertexOut in [[stage_in]],
     float ringRadius1 = sharpRing(decomposed, uniforms.time * 0.1);
     float ringRadius2 = smoothRing(decomposed, uniforms.time * 0.1);
     
-    float inputRadius1 = radius + uniforms.inputVolume * 0.3;
-    float inputRadius2 = radius + uniforms.inputVolume * 0.2;
-    float opacity1 = mix(0.3, 0.8, uniforms.inputVolume);
-    float opacity2 = mix(0.25, 0.6, uniforms.inputVolume);
+    float outputRadius1 = radius + uniforms.outputVolume * 0.3;
+    float outputRadius2 = radius + uniforms.outputVolume * 0.2;
+    float opacity1 = mix(0.3, 0.8, uniforms.outputVolume);
+    float opacity2 = mix(0.25, 0.6, uniforms.outputVolume);
 
-    float ringAlpha1 = (inputRadius2 >= ringRadius1) ? opacity1 : 0.0;
-    float ringAlpha2 = smoothstep(ringRadius2 - 0.05, ringRadius2 + 0.05, inputRadius1) * opacity2;
+    float ringAlpha1 = (outputRadius2 >= ringRadius1) ? opacity1 : 0.0;
+    float ringAlpha2 = smoothstep(ringRadius2 - 0.05, ringRadius2 + 0.05, outputRadius1) * opacity2;
     
     float totalRingAlpha = max(ringAlpha1, ringAlpha2);
     

--- a/Sources/ElevenLabsWidget/ViewModels/ChatWidgetViewModel.swift
+++ b/Sources/ElevenLabsWidget/ViewModels/ChatWidgetViewModel.swift
@@ -36,6 +36,7 @@ final class ChatWidgetViewModel: ObservableObject {
     var onClientToolCall: (@MainActor (ClientToolCallEvent) async -> ClientToolResultEvent)?
     @Published var widgetConfig: ChatWidgetConfig
     let client: ConversationClient
+    let audioLevels = OrbAudioLevels()
 
     /// Tool calls already dispatched, so a re-published snapshot doesn't run them twice.
     private var dispatchedToolCallIds: Set<String> = []
@@ -61,8 +62,15 @@ final class ChatWidgetViewModel: ObservableObject {
         self.conversationConfig = conversationConfig
         self.onClientToolCall = onClientToolCall
 
-        // The client is durable across sessions, so every subscription is wired once.
+        // The client is durable across sessions, so every subscription and
+        // observer is wired once.
+        client.addMicAudioObserver(audioLevels.micMonitor)
+        client.addAgentAudioObserver(audioLevels.agentMonitor)
+
         client.$state.assign(to: &$conversationState)
+        client.$state
+            .sink { [weak self] in self?.audioLevels.isActive = $0.isConnected }
+            .store(in: &cancellables)
         client.$agentState.assign(to: &$agentState)
         client.$isMicMuted.assign(to: &$isMicMuted)
         client.$messages
@@ -153,7 +161,12 @@ final class ChatWidgetViewModel: ObservableObject {
         switch conversationState {
         case .idle, .ended, .error: .disconnected
         case .connecting: .connecting
-        case .connected: agentState == .speaking ? .speaking : .listening
+        case .connected:
+            switch agentState {
+            case .speaking: .speaking
+            case .thinking: .thinking
+            case .listening: .listening
+            }
         }
     }
 

--- a/Sources/ElevenLabsWidget/Views/ChatInputBar.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatInputBar.swift
@@ -29,7 +29,7 @@ struct ChatInputBar: View {
 
             HStack(spacing: 10) {
                 if vm.canToggleMicMute {
-                    ChatMicButton(vm: vm, diameter: 38, theme: theme)
+                    ChatMicButton(vm: vm, levels: vm.audioLevels, diameter: 38, theme: theme)
                 }
                 Spacer(minLength: 0)
                 if vm.canEndConversation {

--- a/Sources/ElevenLabsWidget/Views/ChatMicButton.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatMicButton.swift
@@ -1,21 +1,42 @@
 #if os(iOS)
 import SwiftUI
 
-/// Circular microphone toggle with a muted slash.
+/// Circular microphone toggle with a live input-level fill and a muted slash.
 @available(iOS 16, macCatalyst 16, *)
 struct ChatMicButton: View {
     @ObservedObject var vm: ChatWidgetViewModel
+    /// Observed directly so the fill tracks the mic while redrawing only this button.
+    @ObservedObject var levels: OrbAudioLevels
     let diameter: CGFloat
     var theme: ChatWidgetTheme = .default
 
+    private var micLevel: CGFloat {
+        vm.isMicMuted ? 0 : CGFloat(levels.input)
+    }
+
     var body: some View {
         Button(action: vm.toggleMicMute) {
-            Image(systemName: vm.isMicMuted ? "mic.slash.fill" : "mic.fill")
-                .font(.system(size: diameter * 0.42))
-                .foregroundColor(.primary)
-                .frame(width: diameter, height: diameter)
-                .background(Circle().fill(Color(.systemBackground)))
-                .overlay(Circle().strokeBorder(theme.border, lineWidth: 1))
+            ZStack {
+                Circle().fill(Color(.systemBackground))
+
+                GeometryReader { geometry in
+                    VStack(spacing: 0) {
+                        Spacer(minLength: 0)
+                        Color.accentColor
+                            .opacity(0.18 + micLevel * 0.25)
+                            .frame(height: geometry.size.height * micLevel)
+                    }
+                }
+                .clipShape(Circle())
+
+                Circle().strokeBorder(theme.border, lineWidth: 1)
+
+                Image(systemName: vm.isMicMuted ? "mic.slash.fill" : "mic.fill")
+                    .font(.system(size: diameter * 0.42))
+                    .foregroundColor(.primary)
+            }
+            .frame(width: diameter, height: diameter)
+            .animation(.linear(duration: 0.06), value: micLevel)
         }
         .buttonStyle(.plain)
         .accessibilityLabel(

--- a/Sources/ElevenLabsWidget/Views/ChatOrbView.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatOrbView.swift
@@ -1,39 +1,42 @@
 #if os(iOS)
 import SwiftUI
 
-enum ChatOrbState {
-    case connecting
-    case listening
-    case speaking
-    case disconnected
-}
-
-/// Placeholder orb: a themed gradient sphere that breathes while the agent is
-/// speaking. Replaced by the Metal visualizer without changing its call sites.
+/// The audio-reactive orb, driven by the sampled mic and agent levels.
 @available(iOS 16, macCatalyst 16, *)
 struct ChatOrbView: View {
+    /// Observed here so level changes redraw only the orb, not the whole widget.
+    @ObservedObject var levels: OrbAudioLevels
     let state: ChatOrbState
     let size: CGFloat
     var theme: ChatWidgetTheme = .default
 
-    @State private var isPulsing = false
-
     var body: some View {
-        Circle()
-            .fill(
-                LinearGradient(
-                    colors: [theme.orbSecondary, theme.orbPrimary],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-            )
-            .opacity(state == .disconnected ? 0.55 : 1)
-            .scaleEffect(isPulsing ? 1 : 0.92)
-            .frame(width: size, height: size)
-            // Only the breathing itself repeats; settling back is a one-shot.
-            .animation(isPulsing ? .easeInOut(duration: 0.9).repeatForever(autoreverses: true) : .easeOut(duration: 0.25), value: isPulsing)
-            .onAppear { isPulsing = state == .speaking || state == .connecting }
-            .onChange(of: state) { isPulsing = $0 == .speaking || $0 == .connecting }
+        Orb(
+            color1: theme.orbPrimary,
+            color2: theme.orbSecondary,
+            inputVolume: levels.input,
+            outputVolume: levels.output,
+            agentState: state.visualizerState
+        )
+        .frame(width: size, height: size)
+    }
+}
+
+enum ChatOrbState {
+    case connecting
+    case listening
+    case thinking
+    case speaking
+    case disconnected
+
+    var visualizerState: VisualizerAgentState {
+        switch self {
+        case .connecting: .connecting
+        case .listening: .listening
+        case .thinking: .thinking
+        case .speaking: .speaking
+        case .disconnected: .disconnected
+        }
     }
 }
 #endif

--- a/Sources/ElevenLabsWidget/Views/ChatPopupView.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatPopupView.swift
@@ -100,7 +100,7 @@ struct ChatPopupView: View {
     }
 
     private func orb(size: CGFloat) -> some View {
-        ChatOrbView(state: vm.orbState, size: size, theme: vm.widgetConfig.theme)
+        ChatOrbView(levels: vm.audioLevels, state: vm.orbState, size: size, theme: vm.widgetConfig.theme)
     }
 
     private var header: some View {

--- a/Sources/ElevenLabsWidget/Views/ChatWidget.swift
+++ b/Sources/ElevenLabsWidget/Views/ChatWidget.swift
@@ -112,12 +112,7 @@ public struct ChatWidget: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel(vm.widgetConfig.strings.openChatLabel)
         } else {
-            FloatingChatButton(
-                orbState: vm.orbState,
-                theme: vm.widgetConfig.theme,
-                accessibilityLabel: vm.widgetConfig.strings.openChatLabel,
-                onTap: vm.toggleOpen
-            )
+            FloatingChatButton(vm: vm, onTap: vm.toggleOpen)
         }
     }
 }

--- a/Sources/ElevenLabsWidget/Views/FloatingChatButton.swift
+++ b/Sources/ElevenLabsWidget/Views/FloatingChatButton.swift
@@ -4,18 +4,21 @@ import SwiftUI
 /// Default launcher: a mini orb in the corner of the host UI.
 @available(iOS 16, macCatalyst 16, *)
 struct FloatingChatButton: View {
-    let orbState: ChatOrbState
-    let theme: ChatWidgetTheme
-    let accessibilityLabel: String
+    @ObservedObject var vm: ChatWidgetViewModel
     let onTap: () -> Void
 
     var body: some View {
         Button(action: onTap) {
-            ChatOrbView(state: orbState, size: 58, theme: theme)
-                .shadow(color: .black.opacity(0.18), radius: 10, y: 4)
+            ChatOrbView(
+                levels: vm.audioLevels,
+                state: vm.orbState,
+                size: 58,
+                theme: vm.widgetConfig.theme
+            )
+            .shadow(color: .black.opacity(0.18), radius: 10, y: 4)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(accessibilityLabel)
+        .accessibilityLabel(vm.widgetConfig.strings.openChatLabel)
     }
 }
 #endif

--- a/Tests/ElevenLabsWidgetTests/ConversationAudioLevelMonitorTests.swift
+++ b/Tests/ElevenLabsWidgetTests/ConversationAudioLevelMonitorTests.swift
@@ -1,0 +1,81 @@
+import AVFoundation
+@testable import ElevenLabsWidget
+import XCTest
+
+final class ConversationAudioLevelMonitorTests: XCTestCase {
+    private let monitor = ConversationAudioLevelMonitor()
+
+    func testStartsSilent() {
+        XCTAssertEqual(monitor.sample(), 0)
+    }
+
+    func testToneRaisesLevel() throws {
+        try monitor.didReceive(tone(amplitude: 0.5))
+        XCTAssertGreaterThan(monitor.sample(), 0.5)
+    }
+
+    func testLouderToneGivesHigherLevel() throws {
+        try monitor.didReceive(tone(amplitude: 0.05))
+        let quiet = monitor.sample()
+        monitor.reset()
+        try monitor.didReceive(tone(amplitude: 1))
+        XCTAssertGreaterThan(monitor.sample(), quiet)
+    }
+
+    func testLevelHoldsThePeakBetweenReads() throws {
+        try monitor.didReceive(tone(amplitude: 1))
+        let loud = monitor.sample()
+        monitor.reset()
+        try monitor.didReceive(tone(amplitude: 1))
+        try monitor.didReceive(tone(amplitude: 0))
+        XCTAssertEqual(monitor.sample(), loud)
+    }
+
+    /// Decay is paced by reads, so a stream that stops delivering still fades.
+    func testSilenceDecaysWithoutReachingZero() throws {
+        try monitor.didReceive(tone(amplitude: 1))
+        let loud = monitor.sample()
+        let decayed = monitor.sample()
+        XCTAssertLessThan(decayed, loud)
+        XCTAssertGreaterThan(decayed, 0)
+        XCTAssertLessThan(monitor.sample(), decayed)
+    }
+
+    func testResetClearsLevel() throws {
+        try monitor.didReceive(tone(amplitude: 1))
+        monitor.reset()
+        XCTAssertEqual(monitor.sample(), 0)
+    }
+
+    func testEmptyBufferIsIgnored() throws {
+        let buffer = try tone(amplitude: 1)
+        buffer.frameLength = 0
+        monitor.didReceive(buffer)
+        XCTAssertEqual(monitor.sample(), 0)
+    }
+
+    func testInt16BufferRaisesLevel() throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatInt16, sampleRate: 48000, channels: 1, interleaved: false
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 1024))
+        buffer.frameLength = 1024
+        let samples = try XCTUnwrap(buffer.int16ChannelData)[0]
+        for frame in 0 ..< 1024 {
+            samples[frame] = Int16(Float(Int16.max) * 0.5 * sin(2 * .pi * 440 * Float(frame) / 48000))
+        }
+        monitor.didReceive(buffer)
+        XCTAssertGreaterThan(monitor.sample(), 0.5)
+    }
+
+    private func tone(amplitude: Float, frames: AVAudioFrameCount = 1024) throws -> AVAudioPCMBuffer {
+        let format = try XCTUnwrap(AVAudioFormat(standardFormatWithSampleRate: 48000, channels: 1))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames))
+        buffer.frameLength = frames
+        let samples = try XCTUnwrap(buffer.floatChannelData)[0]
+        for frame in 0 ..< Int(frames) {
+            samples[frame] = amplitude * sin(2 * .pi * 440 * Float(frame) / 48000)
+        }
+        return buffer
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the placeholder orb with the Metal orb from [components-swift](https://github.com/livekit-examples/components-swift) (Apache-2.0), reacting to live audio.

- `Rendering/Orb.swift`, `Rendering/VisualizerAgentState.swift`, `Resources/OrbShader.metal`: ported and trimmed to what the widget needs. The LiveKit dependency is gone, so the orb runs on plain audio levels.
- `ConversationAudioLevelMonitor`: a `ConversationAudioObserver` (from #215) that keeps a normalized loudness level with fast attack and slow release, computed on the audio thread for both float32 and int16 buffers.
- `OrbAudioLevels`: samples the mic and agent monitors on a timer and publishes the two levels the orb renders from.
- The three orb sites — launcher, drawer header, and the large idle orb — all run the real thing now, and the mic button shows a live input level.

## Test plan

- [x] `swift build`, `swift test` (new `ConversationAudioLevelMonitorTests`), `swiftformat . --strict`
- [x] `xcodebuild` of `Examples/DemoApp` for the iOS simulator
- [x] Manual: orb reacts while the agent speaks and while talking into the mic; goes still when the call ends

https://github.com/user-attachments/assets/edddd26b-cd3a-4fb3-82e1-8245856fcdb7


Stacked on #224.
