### PR TITLE
feat: wait for conversation initiation metadata (duplicate of #213)

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -77,6 +77,7 @@ conversation.$state
             print("Connecting: \(stage)")
         case .connected(let callInfo):
             print("Connected to agent: \(callInfo.agentId)")
+            print("Conversation ID: \(callInfo.conversationId)")
         case .ended(let reason):
             print("Conversation ended: \(reason)")
         case .error(let error):
@@ -520,20 +521,17 @@ let config = ConversationConfig(audioConfiguration: audioConfig)
 
 ---
 
-## Startup Performance Tuning {#startup-tuning}
+## Startup Timeouts {#startup-tuning}
 
-Control the connection handshake and retry behavior.
+Control how long startup waits for the agent and conversation metadata.
 
 ```swift
 let startupConfig = ConversationStartupConfiguration(
-    // Time to wait for agent to be 'ready' after room connection
+    // Time to wait for the agent after the room connects
     agentReadyTimeout: 10.0,
-    
-    // Backoff strategy for protocol initialization 
-    initRetryDelays: [0, 1.0, 2.0, 5.0],
-    
-    // Whether to fail early if agent takes too long
-    failIfAgentNotReady: true
+
+    // Time to wait for the server to initialize the conversation
+    initiationMetadataTimeout: 5.0
 )
 
 let config = ConversationConfig(startupConfiguration: startupConfig)

--- a/Sources/ElevenLabs/Internal/Conversation/ConnectionManaging.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/ConnectionManaging.swift
@@ -33,9 +33,16 @@ protocol WebRTCConnectionManaging: ConnectionManaging {
 }
 
 extension ConnectionManaging {
-    func handleIncomingData(_ data: Data, logger: any Logging) {
+    func handleIncomingData(
+        _ data: Data,
+        metadataWaiter: ConversationInitiationMetadataWaiter,
+        logger: any Logging
+    ) {
         do {
             if let event = try EventParser.parseIncomingEvent(from: data) {
+                if case let .conversationMetadata(metadata) = event {
+                    Task { await metadataWaiter.observe(metadata) }
+                }
                 onEventReceived?(event)
             }
         } catch let EventParseError.unknownEventType(type) {
@@ -55,5 +62,23 @@ extension ConnectionManaging {
         } catch ConnectionManagerError.notConnected {
             throw ConversationError.notConnected
         }
+    }
+
+    @MainActor
+    func waitForInitiationMetadata(
+        config: ConversationConfig,
+        metrics: inout ConversationStartupMetrics,
+        startTime: Date,
+        metadataWaiter: ConversationInitiationMetadataWaiter,
+        onStartupStateChange: (ConversationStartupState) -> Void
+    ) async throws -> ConversationMetadataEvent {
+        let timeout = config.startupConfiguration.initiationMetadataTimeout
+        onStartupStateChange(.waitingForInitiationMetadata(timeout: timeout))
+
+        let waitStart = Date()
+        let metadata = try await metadataWaiter.wait()
+        metrics.initiationMetadata = Date().timeIntervalSince(waitStart)
+        metrics.total = Date().timeIntervalSince(startTime)
+        return metadata
     }
 }

--- a/Sources/ElevenLabs/Internal/Conversation/ConversationInitiationMetadataWaiter.swift
+++ b/Sources/ElevenLabs/Internal/Conversation/ConversationInitiationMetadataWaiter.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+actor ConversationInitiationMetadataWaiter {
+    private let timeoutNanoseconds: UInt64
+    private var outcome: Result<ConversationMetadataEvent, Error>?
+    private var continuation: CheckedContinuation<ConversationMetadataEvent, Error>?
+    private var timeoutTask: Task<Void, Never>?
+
+    init(timeout: TimeInterval) {
+        timeoutNanoseconds = UInt64(timeout * 1_000_000_000)
+    }
+
+    func observe(_ metadata: ConversationMetadataEvent) {
+        complete(.success(metadata))
+    }
+
+    func wait() async throws -> ConversationMetadataEvent {
+        if let outcome { return try outcome.get() }
+        if Task.isCancelled {
+            let error = CancellationError()
+            complete(.failure(error))
+            throw error
+        }
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if let outcome {
+                    continuation.resume(with: outcome)
+                    return
+                }
+                precondition(self.continuation == nil, "Only one metadata wait is allowed")
+                self.continuation = continuation
+                startTimeout()
+            }
+        } onCancel: {
+            Task { await self.cancel() }
+        }
+    }
+
+    func cancel() {
+        complete(.failure(CancellationError()))
+    }
+
+    private func startTimeout() {
+        guard timeoutTask == nil else { return }
+        timeoutTask = Task { [weak self, timeoutNanoseconds] in
+            do {
+                try await Task.sleep(nanoseconds: timeoutNanoseconds)
+            } catch {
+                return
+            }
+            await self?.complete(.failure(ConversationError.initiationMetadataTimeout))
+        }
+    }
+
+    private func complete(_ outcome: Result<ConversationMetadataEvent, Error>) {
+        guard self.outcome == nil else { return }
+        self.outcome = outcome
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        continuation?.resume(with: outcome)
+        continuation = nil
+    }
+}

--- a/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebRTCConnectionManager.swift
@@ -58,6 +58,7 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
 
     private var eventDelegate: LiveKitRoomEventDelegate?
     private var readinessDelegate: LiveKitReadinessDelegate?
+    private var initiationMetadataWaiter: ConversationInitiationMetadataWaiter?
 
     private static let reliableDataPublishOptions = DataPublishOptions(reliable: true)
 
@@ -72,13 +73,18 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
     // MARK: – Public API
 
     /// Full WebRTC startup sequence: resolve token → request mic permission →
-    /// connect room → wait for agent → send conversation_init (sent once).
+    /// connect room → wait for agent → send init → wait for initiation metadata.
     @MainActor
     func connect(
         auth: ConversationCredentials,
         config: ConversationConfig,
         onStartupStateChange: @escaping (ConversationStartupState) -> Void
     ) async throws -> ConversationStartResult {
+        await initiationMetadataWaiter?.cancel()
+        let waiter = ConversationInitiationMetadataWaiter(
+            timeout: config.startupConfiguration.initiationMetadataTimeout
+        )
+        initiationMetadataWaiter = waiter
         let startTime = Date()
         var metrics = ConversationStartupMetrics()
         logger.info("Starting conversation startup sequence", context: ["agentId": auth.agentId])
@@ -104,7 +110,8 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
                 details: connectionDetails,
                 enableMic: permissionGranted,
                 throwOnMicrophoneFailure: throwOnMicFailure,
-                networkConfiguration: config.networkConfiguration
+                networkConfiguration: config.networkConfiguration,
+                metadataWaiter: waiter
             )
         }
 
@@ -127,9 +134,15 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
             try await send(event: .conversationInit(ConversationInitEvent(config: config)))
         }
 
-        metrics.total = Date().timeIntervalSince(startTime)
+        let metadata = try await waitForInitiationMetadata(
+            config: config,
+            metrics: &metrics,
+            startTime: startTime,
+            metadataWaiter: waiter,
+            onStartupStateChange: onStartupStateChange
+        )
         return ConversationStartResult(
-            callInfo: CallInfo(agentId: auth.agentId),
+            callInfo: CallInfo(agentId: auth.agentId, conversationId: metadata.conversationId),
             metrics: metrics
         )
     }
@@ -199,7 +212,8 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
         details: TokenService.ConnectionDetails,
         enableMic: Bool,
         throwOnMicrophoneFailure: Bool,
-        networkConfiguration: WebRTCConfiguration
+        networkConfiguration: WebRTCConfiguration,
+        metadataWaiter: ConversationInitiationMetadataWaiter
     ) async throws {
         await readinessDelegate?.release()
 
@@ -208,7 +222,9 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
 
         let logger = logger
         let eventDelegate = LiveKitRoomEventDelegate(
-            onData: { [weak self] data in self?.handleIncomingData(data, logger: logger) },
+            onData: { [weak self] data in
+                self?.handleIncomingData(data, metadataWaiter: metadataWaiter, logger: logger)
+            },
             onRemoteSpeaking: { [weak self] isSpeaking in self?.onRemoteSpeakingChanged?(isSpeaking) },
             onRemoteDisconnect: { [weak self] in await self?.onDisconnected?() }
         )
@@ -261,6 +277,8 @@ final class WebRTCConnectionManager: WebRTCConnectionManaging {
         errorHandler = nil
         onRemoteSpeakingChanged = nil
 
+        await initiationMetadataWaiter?.cancel()
+        initiationMetadataWaiter = nil
         await readinessDelegate?.release()
         readinessDelegate = nil
 

--- a/Sources/ElevenLabs/Internal/Networking/WebSocketConnectionManager.swift
+++ b/Sources/ElevenLabs/Internal/Networking/WebSocketConnectionManager.swift
@@ -4,8 +4,8 @@ import Foundation
 ///
 /// Opens a single `URLSessionWebSocketTask` to the text conversation endpoint,
 /// sends `conversationInit` once the socket is open, then runs a receive loop
-/// that parses incoming JSON into `IncomingEvent`s and forwards them via
-/// `onEventReceived`. On runtime socket error, fires `onDisconnected` once.
+/// that forwards incoming events and waits for initiation metadata. On runtime
+/// socket error, fires `onDisconnected` once.
 ///
 /// Used instead of `WebRTCConnectionManager` because the WebRTC transport
 /// drops rooms with no audio — text-only needs a transport that stays open
@@ -19,6 +19,7 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
     private let logger: any Logging
     private var task: URLSessionWebSocketTask?
     private var receiveTask: Task<Void, Never>?
+    private var initiationMetadataWaiter: ConversationInitiationMetadataWaiter?
 
     init(logger: any Logging) {
         self.logger = logger
@@ -35,6 +36,11 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
         config: ConversationConfig,
         onStartupStateChange: @escaping (ConversationStartupState) -> Void
     ) async throws -> ConversationStartResult {
+        await initiationMetadataWaiter?.cancel()
+        let waiter = ConversationInitiationMetadataWaiter(
+            timeout: config.startupConfiguration.initiationMetadataTimeout
+        )
+        initiationMetadataWaiter = waiter
         let startTime = Date()
         var metrics = ConversationStartupMetrics()
 
@@ -69,12 +75,18 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
         // Socket is up and the init message is sent. Start consuming responses.
         receiveTask = Task { [weak self, weak task] in
             guard let self, let task else { return }
-            await receiveLoop(task: task)
+            await receiveLoop(task: task, metadataWaiter: waiter)
         }
 
-        metrics.total = Date().timeIntervalSince(startTime)
+        let metadata = try await waitForInitiationMetadata(
+            config: config,
+            metrics: &metrics,
+            startTime: startTime,
+            metadataWaiter: waiter,
+            onStartupStateChange: onStartupStateChange
+        )
         return ConversationStartResult(
-            callInfo: CallInfo(agentId: auth.agentId),
+            callInfo: CallInfo(agentId: auth.agentId, conversationId: metadata.conversationId),
             metrics: metrics
         )
     }
@@ -91,6 +103,8 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
         onDisconnected = nil
         errorHandler = nil
 
+        await initiationMetadataWaiter?.cancel()
+        initiationMetadataWaiter = nil
         receiveTask?.cancel()
         receiveTask = nil
         task?.cancel(with: .normalClosure, reason: nil)
@@ -104,13 +118,20 @@ final class WebSocketConnectionManager: WebSocketConnectionManaging {
         }
     }
 
-    private func receiveLoop(task: URLSessionWebSocketTask) async {
+    private func receiveLoop(
+        task: URLSessionWebSocketTask,
+        metadataWaiter: ConversationInitiationMetadataWaiter
+    ) async {
         while !Task.isCancelled {
             do {
                 let message = try await task.receive()
                 switch message {
                 case let .string(text):
-                    handleIncomingData(Data(text.utf8), logger: logger)
+                    handleIncomingData(
+                        Data(text.utf8),
+                        metadataWaiter: metadataWaiter,
+                        logger: logger
+                    )
                 case .data:
                     logger.warning("Ignoring binary WebSocket message")
                 @unknown default:

--- a/Sources/ElevenLabs/Public/Conversation/ConversationError.swift
+++ b/Sources/ElevenLabs/Public/Conversation/ConversationError.swift
@@ -6,6 +6,7 @@ public enum ConversationError: LocalizedError, Sendable, Equatable {
     case connectionFailed(String) // Store error description instead of Error for Equatable
     case authenticationFailed(String)
     case agentTimeout
+    case initiationMetadataTimeout
     case microphoneToggleFailed(String) // Store error description instead of Error for Equatable
     case serverError(ErrorEvent)
 
@@ -25,6 +26,7 @@ public enum ConversationError: LocalizedError, Sendable, Equatable {
         case let .connectionFailed(description): "Connection failed: \(description)"
         case let .authenticationFailed(msg): "Authentication failed: \(msg)"
         case .agentTimeout: "Agent did not join in time."
+        case .initiationMetadataTimeout: "Conversation metadata was not received in time."
         case let .microphoneToggleFailed(description): "Failed to toggle microphone: \(description)"
         case let .serverError(event): "Server error (\(event.code)): \(event.message ?? "unknown")"
         }

--- a/Sources/ElevenLabs/Public/Conversation/Models/CallInfo.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Models/CallInfo.swift
@@ -2,4 +2,5 @@ import Foundation
 
 public struct CallInfo: Equatable, Sendable {
     public let agentId: String
+    public let conversationId: String
 }

--- a/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupConfiguration.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupConfiguration.swift
@@ -2,11 +2,14 @@ import Foundation
 
 public struct ConversationStartupConfiguration: Sendable, Equatable {
     public var agentReadyTimeout: TimeInterval
+    public var initiationMetadataTimeout: TimeInterval
 
     public init(
-        agentReadyTimeout: TimeInterval = 3.0
+        agentReadyTimeout: TimeInterval = 3.0,
+        initiationMetadataTimeout: TimeInterval = 5.0
     ) {
         self.agentReadyTimeout = agentReadyTimeout
+        self.initiationMetadataTimeout = initiationMetadataTimeout
     }
 
     public static let `default` = ConversationStartupConfiguration()

--- a/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupMetrics.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupMetrics.swift
@@ -8,6 +8,7 @@ public struct ConversationStartupMetrics: Sendable, Equatable {
 
     public var agentReadyBuffer: TimeInterval?
     public var conversationInit: TimeInterval?
+    public var initiationMetadata: TimeInterval?
 
     public init(
         total: TimeInterval? = nil,
@@ -17,7 +18,8 @@ public struct ConversationStartupMetrics: Sendable, Equatable {
         agentReadyViaGraceTimeout _: Bool = false,
         agentReadyTimedOut _: Bool = false,
         agentReadyBuffer: TimeInterval? = nil,
-        conversationInit: TimeInterval? = nil
+        conversationInit: TimeInterval? = nil,
+        initiationMetadata: TimeInterval? = nil
     ) {
         self.total = total
         self.tokenFetch = tokenFetch
@@ -25,5 +27,6 @@ public struct ConversationStartupMetrics: Sendable, Equatable {
         self.agentReady = agentReady
         self.agentReadyBuffer = agentReadyBuffer
         self.conversationInit = conversationInit
+        self.initiationMetadata = initiationMetadata
     }
 }

--- a/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupState.swift
+++ b/Sources/ElevenLabs/Public/Conversation/Startup/ConversationStartupState.swift
@@ -9,4 +9,5 @@ public enum ConversationStartupState: Sendable, Equatable {
     case waitingForAgent(timeout: TimeInterval)
     case agentReady(ConversationAgentReadyReport)
     case sendingConversationInit
+    case waitingForInitiationMetadata(timeout: TimeInterval)
 }

--- a/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
+++ b/Tests/ElevenLabsTests/Mocks/MockWebRTCConnectionManager.swift
@@ -19,6 +19,7 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
     }
 
     var onRemoteSpeakingChanged: (@Sendable (Bool) -> Void)?
+    private var initiationMetadataWaiter: ConversationInitiationMetadataWaiter?
 
     private var eventHandlerInstalled: CheckedContinuation<Void, Never>?
 
@@ -35,6 +36,8 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
     var tokenError: ConversationError?
     var publishError: Swift.Error?
     var microphoneError: Swift.Error?
+    var autoDeliverInitiationMetadata = true
+    var initiationMetadataConversationId = "test-conversation-id"
 
     private(set) var connectCallCount = 0
     private(set) var disconnectCallCount = 0
@@ -60,6 +63,12 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
         onStartupStateChange: @escaping (ConversationStartupState) -> Void
     ) async throws -> ConversationStartResult {
         startupStateChange = onStartupStateChange
+        await initiationMetadataWaiter?.cancel()
+        let waiter = ConversationInitiationMetadataWaiter(
+            timeout: config.startupConfiguration.initiationMetadataTimeout
+        )
+        initiationMetadataWaiter = waiter
+        let startTime = Date()
         connectCallCount += 1
         lastNetworkConfiguration = config.networkConfiguration
         var metrics = ConversationStartupMetrics()
@@ -93,8 +102,21 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
             throw error as? ConversationError ?? ConversationError.connectionFailed(error)
         }
 
+        if autoDeliverInitiationMetadata {
+            let metadata = makeInitiationMetadata()
+            await waiter.observe(metadata)
+            onEventReceived?(.conversationMetadata(metadata))
+        }
+
+        let metadata = try await waitForInitiationMetadata(
+            config: config,
+            metrics: &metrics,
+            startTime: startTime,
+            metadataWaiter: waiter,
+            onStartupStateChange: onStartupStateChange
+        )
         return ConversationStartResult(
-            callInfo: CallInfo(agentId: auth.agentId),
+            callInfo: CallInfo(agentId: auth.agentId, conversationId: metadata.conversationId),
             metrics: metrics
         )
     }
@@ -110,6 +132,8 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
         errorHandler = nil
         onRemoteSpeakingChanged = nil
         room = nil
+        await initiationMetadataWaiter?.cancel()
+        initiationMetadataWaiter = nil
     }
 
     @MainActor
@@ -153,7 +177,14 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
     // MARK: - Helpers
 
     func receive(data: Data) {
-        handleIncomingData(data, logger: SDKLogger(logLevel: .error))
+        guard let initiationMetadataWaiter else {
+            preconditionFailure("Cannot receive data before connecting")
+        }
+        handleIncomingData(
+            data,
+            metadataWaiter: initiationMetadataWaiter,
+            logger: SDKLogger(logLevel: .error)
+        )
     }
 
     /// Delivers an already-decoded event directly to the installed handler
@@ -186,5 +217,13 @@ final class MockWebRTCConnectionManager: WebRTCConnectionManaging {
         } else {
             pendingWaitResult = result
         }
+    }
+
+    private func makeInitiationMetadata() -> ConversationMetadataEvent {
+        ConversationMetadataEvent(
+            conversationId: initiationMetadataConversationId,
+            agentOutputAudioFormat: "pcm_16000",
+            userInputAudioFormat: "pcm_16000"
+        )
     }
 }

--- a/Tests/ElevenLabsTests/Mocks/MockWebSocketConnectionManager.swift
+++ b/Tests/ElevenLabsTests/Mocks/MockWebSocketConnectionManager.swift
@@ -5,9 +5,12 @@ final class MockWebSocketConnectionManager: WebSocketConnectionManaging {
     var onEventReceived: (@Sendable (IncomingEvent) -> Void)?
     var onDisconnected: (() async -> Void)?
     var errorHandler: ((Swift.Error?) -> Void)?
+    private var initiationMetadataWaiter: ConversationInitiationMetadataWaiter?
 
     var connectError: Error?
     var sendError: Error?
+    var autoDeliverInitiationMetadata = true
+    var initiationMetadataConversationId = "test-conversation-id"
 
     private(set) var connectCallCount = 0
     private(set) var disconnectCallCount = 0
@@ -21,6 +24,11 @@ final class MockWebSocketConnectionManager: WebSocketConnectionManaging {
         config: ConversationConfig,
         onStartupStateChange: @escaping (ConversationStartupState) -> Void
     ) async throws -> ConversationStartResult {
+        await initiationMetadataWaiter?.cancel()
+        let waiter = ConversationInitiationMetadataWaiter(
+            timeout: config.startupConfiguration.initiationMetadataTimeout
+        )
+        initiationMetadataWaiter = waiter
         connectCallCount += 1
         let startTime = Date()
         var metrics = ConversationStartupMetrics()
@@ -52,9 +60,21 @@ final class MockWebSocketConnectionManager: WebSocketConnectionManaging {
             throw error as? ConversationError ?? ConversationError.connectionFailed(error)
         }
 
-        metrics.total = Date().timeIntervalSince(startTime)
+        if autoDeliverInitiationMetadata {
+            let metadata = makeInitiationMetadata()
+            await waiter.observe(metadata)
+            onEventReceived?(.conversationMetadata(metadata))
+        }
+
+        let metadata = try await waitForInitiationMetadata(
+            config: config,
+            metrics: &metrics,
+            startTime: startTime,
+            metadataWaiter: waiter,
+            onStartupStateChange: onStartupStateChange
+        )
         return ConversationStartResult(
-            callInfo: CallInfo(agentId: auth.agentId),
+            callInfo: CallInfo(agentId: auth.agentId, conversationId: metadata.conversationId),
             metrics: metrics
         )
     }
@@ -65,6 +85,8 @@ final class MockWebSocketConnectionManager: WebSocketConnectionManaging {
         onDisconnected = nil
         errorHandler = nil
         isConnected = false
+        await initiationMetadataWaiter?.cancel()
+        initiationMetadataWaiter = nil
     }
 
     func send(data: Data) async throws {
@@ -79,6 +101,21 @@ final class MockWebSocketConnectionManager: WebSocketConnectionManaging {
     }
 
     func receive(data: Data) {
-        handleIncomingData(data, logger: SDKLogger(logLevel: .error))
+        guard let initiationMetadataWaiter else {
+            preconditionFailure("Cannot receive data before connecting")
+        }
+        handleIncomingData(
+            data,
+            metadataWaiter: initiationMetadataWaiter,
+            logger: SDKLogger(logLevel: .error)
+        )
+    }
+
+    private func makeInitiationMetadata() -> ConversationMetadataEvent {
+        ConversationMetadataEvent(
+            conversationId: initiationMetadataConversationId,
+            agentOutputAudioFormat: "pcm_16000",
+            userInputAudioFormat: "pcm_16000"
+        )
     }
 }

--- a/Tests/ElevenLabsTests/Unit/ConversationInitiationMetadataWaiterTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationInitiationMetadataWaiterTests.swift
@@ -1,0 +1,76 @@
+@testable import ElevenLabs
+import XCTest
+
+final class ConversationInitiationMetadataWaiterTests: XCTestCase {
+    func testMetadataReceivedBeforeWait() async throws {
+        let waiter = ConversationInitiationMetadataWaiter(timeout: 1)
+        await waiter.observe(makeMetadata(conversationId: "early"))
+
+        let metadata = try await waiter.wait()
+
+        XCTAssertEqual(metadata.conversationId, "early")
+    }
+
+    func testFirstMetadataWins() async throws {
+        let waiter = ConversationInitiationMetadataWaiter(timeout: 1)
+        await waiter.observe(makeMetadata(conversationId: "first"))
+        await waiter.observe(makeMetadata(conversationId: "second"))
+
+        let metadata = try await waiter.wait()
+
+        XCTAssertEqual(metadata.conversationId, "first")
+    }
+
+    func testTimeout() async {
+        let waiter = ConversationInitiationMetadataWaiter(timeout: 0.01)
+
+        await XCTAssertThrowsErrorAsync {
+            try await waiter.wait()
+        } errorHandler: { error in
+            XCTAssertEqual(error as? ConversationError, .initiationMetadataTimeout)
+        }
+    }
+
+    func testTimeoutIsTerminal() async {
+        let waiter = ConversationInitiationMetadataWaiter(timeout: 0)
+
+        await XCTAssertThrowsErrorAsync {
+            try await waiter.wait()
+        }
+        await waiter.observe(makeMetadata(conversationId: "late"))
+        await XCTAssertThrowsErrorAsync {
+            try await waiter.wait()
+        } errorHandler: { error in
+            XCTAssertEqual(error as? ConversationError, .initiationMetadataTimeout)
+        }
+    }
+
+    func testCancellationIsTerminal() async {
+        let waiter = ConversationInitiationMetadataWaiter(timeout: 1)
+        let waitTask = Task { try await waiter.wait() }
+
+        waitTask.cancel()
+
+        do {
+            _ = try await waitTask.value
+            XCTFail("Expected cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+
+        await waiter.observe(makeMetadata(conversationId: "late"))
+        await XCTAssertThrowsErrorAsync {
+            try await waiter.wait()
+        } errorHandler: { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+    }
+
+    private func makeMetadata(conversationId: String) -> ConversationMetadataEvent {
+        ConversationMetadataEvent(
+            conversationId: conversationId,
+            agentOutputAudioFormat: "pcm_16000",
+            userInputAudioFormat: "pcm_16000"
+        )
+    }
+}

--- a/Tests/ElevenLabsTests/Unit/ConversationTests.swift
+++ b/Tests/ElevenLabsTests/Unit/ConversationTests.swift
@@ -56,8 +56,10 @@ final class ConversationTests: XCTestCase {
             return XCTFail("Expected connected state")
         }
         XCTAssertEqual(callInfo.agentId, "test-agent-id")
+        XCTAssertEqual(callInfo.conversationId, "test-conversation-id")
         XCTAssertEqual(result.callInfo, callInfo)
         XCTAssertEqual(result.metrics.agentReady, 0)
+        XCTAssertNotNil(result.metrics.initiationMetadata)
         let errorsAfterSuccess = await capturedErrors.values()
         XCTAssertTrue(errorsAfterSuccess.isEmpty)
     }
@@ -89,6 +91,7 @@ final class ConversationTests: XCTestCase {
     func testStartConversationHandlesIncomingDataBeforeAgentReady() async throws {
         // Hold agent-ready so we can deliver protocol data while still connecting.
         mockWebRTCConnectionManager.autoSucceedAgentReady = false
+        mockWebRTCConnectionManager.autoDeliverInitiationMetadata = false
 
         let startTask = Task {
             guard let conversation = self.conversation else { return }
@@ -123,6 +126,11 @@ final class ConversationTests: XCTestCase {
 
         mockWebRTCConnectionManager.succeedAgentReady()
         try await startTask.value
+
+        guard case let .connected(callInfo) = conversation.state else {
+            return XCTFail("Expected connected state")
+        }
+        XCTAssertEqual(callInfo.conversationId, "conversation-before-ready")
     }
 
     func testStaleProtocolDataHandlerDoesNotMutateEndedConversation() async throws {
@@ -178,8 +186,11 @@ final class ConversationTests: XCTestCase {
         )
         cancellable?.cancel()
 
-        let reportedStartupStages = await waitForValues(startupStages, count: 2)
-        XCTAssertEqual(reportedStartupStages, [.preparing, .sendingConversationInit])
+        let reportedStartupStages = await waitForValues(startupStages, count: 3)
+        XCTAssertEqual(
+            reportedStartupStages,
+            [.preparing, .sendingConversationInit, .waitingForInitiationMetadata(timeout: 5.0)]
+        )
         XCTAssertEqual(mockWebRTCConnectionManager.connectCallCount, 0)
         XCTAssertEqual(mockWebSocketConnectionManager.connectCallCount, 1)
         XCTAssertEqual(mockWebSocketConnectionManager.lastConnectedURL?.scheme, "wss")
@@ -466,6 +477,28 @@ final class ConversationTests: XCTestCase {
         XCTAssertEqual(errorsAfterAgentTimeout, [.agentTimeout])
     }
 
+    func testStartConversationInitiationMetadataTimeout() async {
+        mockWebRTCConnectionManager.autoDeliverInitiationMetadata = false
+
+        let startupConfig = ConversationStartupConfiguration(initiationMetadataTimeout: 0.01)
+        let config = makeConfig(startupConfiguration: startupConfig)
+
+        await XCTAssertThrowsErrorAsync {
+            _ = try await conversation.startConversation(
+                auth: .publicAgent(id: "test-agent"),
+                config: config
+            )
+        } errorHandler: { error in
+            XCTAssertEqual(error as? ConversationError, .initiationMetadataTimeout)
+        }
+
+        guard case .error(.initiationMetadataTimeout) = conversation.state else {
+            return XCTFail("Expected initiation metadata timeout error state")
+        }
+        let errorsAfterTimeout = await waitForValues(capturedErrors, count: 1)
+        XCTAssertEqual(errorsAfterTimeout, [.initiationMetadataTimeout])
+    }
+
     func testStartConversationConversationInitFailure() async {
         mockWebRTCConnectionManager.publishError = ConversationError.connectionFailed("Publish failed")
 
@@ -613,6 +646,7 @@ final class ConversationTests: XCTestCase {
         XCTAssertEqual(ConversationError.authenticationFailed("test"), ConversationError.authenticationFailed("test"))
         XCTAssertEqual(ConversationError.connectionFailed("test"), ConversationError.connectionFailed("test"))
         XCTAssertEqual(ConversationError.agentTimeout, ConversationError.agentTimeout)
+        XCTAssertEqual(ConversationError.initiationMetadataTimeout, ConversationError.initiationMetadataTimeout)
         XCTAssertEqual(ConversationError.microphoneToggleFailed("test"), ConversationError.microphoneToggleFailed("test"))
 
         XCTAssertNotEqual(ConversationError.notConnected, ConversationError.alreadyActive)
@@ -621,7 +655,9 @@ final class ConversationTests: XCTestCase {
     func testConversationStateEnum() {
         let idleState: ConversationState = .idle
         let connectingState: ConversationState = .connecting(.preparing)
-        let connectedState: ConversationState = .connected(CallInfo(agentId: "test"))
+        let connectedState: ConversationState = .connected(
+            CallInfo(agentId: "test", conversationId: "conversation")
+        )
 
         XCTAssertNotEqual(idleState, connectingState)
         XCTAssertNotEqual(connectingState, connectedState)


### PR DESCRIPTION
Duplicate of https://github.com/elevenlabs/elevenlabs-swift-sdk/pull/213
I accidentally merged it into a wrong branch 🤦 

Already reviewed and stamped.

## Summary

Conversation startup now waits for server initiation metadata before returning. That metadata is what gives us `conversation_id` which will be needed for various purposes (file upload, post-call feedback, logging, etc).
This shouldn't add about latency because the server sends metadata immediately as soon as it receives connection.

As a result:

- `.connected(CallInfo)` always includes the conversation ID.
- `ConversationStartResult` returns complete call information and startup metrics.
- WebRTC and WebSocket use the same readiness contract.
- Metadata wait time is measured separately.
- Missing metadata fails with a configurable timeout.
- Early metadata and cancellation are handled by a one-shot, per-connection waiter.


## Testing

- unit tests, manual test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core connection handshake and adds a required CallInfo field, so callers must handle metadata timeout and update any CallInfo construction; behavior is well-covered by new unit tests.
> 
> **Overview**
> Conversation **startup no longer completes** until the server sends **conversation initiation metadata**. WebRTC and WebSocket transports share a per-connection **`ConversationInitiationMetadataWaiter`** that resolves on the first metadata event (or fails on timeout/cancel).
> 
> **`CallInfo`** now includes **`conversationId`**, so `.connected` and **`ConversationStartResult`** always carry the ID once startup succeeds. Incoming **`conversationMetadata`** events feed the waiter via **`handleIncomingData`**, including metadata that arrives before agent-ready.
> 
> New public surface: **`ConversationError.initiationMetadataTimeout`**, **`ConversationStartupConfiguration.initiationMetadataTimeout`** (default 5s), startup stage **`waitingForInitiationMetadata`**, and **`ConversationStartupMetrics.initiationMetadata`**. Docs describe startup timeouts instead of the old retry tuning example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce4229a310fee8c5f1a87c4852fe00234c2f9e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->